### PR TITLE
NewtonsoftJson.Codec: Provide up/down conversion hooks and metadata access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,13 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `tests/FsCodec.NewtonsoftJson.Tests/examples.fsx` counterpart to the `README.md`
 - Exposed `TypeSafeEnum`
 - `IndexedEventData` type to replace usage of impromptu objects
+- overload with `up`/`down` arguments on `FsCodec.NewtonsoftJson.Codec.Create` facilitating surfacing index, metadata, and other such information in the event as surfaced to the programming model functions [#17](https://github.com/jet/FsCodec/pull/17)
 
 ### Changed
 ### Removed
+
+- `FsCodec.NewtonsoftJson.Codec.Create` overload with `genMetadata` and `genTimestamp` arguments (equivalent functionality can be achieved via `up`/`down` arguments) [#17](https://github.com/jet/FsCodec/pull/17)
+
 ### Fixed
 
 - Pushed `TypeShape`'s `PackageReference` down into `FsCodec.NewtonsoftJson`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - overload with `up`/`down` arguments on `FsCodec.NewtonsoftJson.Codec.Create` facilitating surfacing index, metadata, and other such information in the event as surfaced to the programming model functions [#17](https://github.com/jet/FsCodec/pull/17)
 
 ### Changed
+
+- `IUnionEncoder.TryDecode` now operates on `IIndexedEvent` (which moves to `FsCodec` from `FsCodec.Core`) instead of `IEvent`
+
 ### Removed
 
 - `FsCodec.NewtonsoftJson.Codec.Create` overload with `genMetadata` and `genTimestamp` arguments (equivalent functionality can be achieved via `up`/`down` arguments) [#17](https://github.com/jet/FsCodec/pull/17)

--- a/src/FsCodec.NewtonsoftJson/Codec.fs
+++ b/src/FsCodec.NewtonsoftJson/Codec.fs
@@ -55,21 +55,21 @@ type Codec private () =
     static let defaultSettings = lazy Settings.Create()
 
     /// Generate a codec suitable for use with <c>Equinox.EventStore</c>, <c>Equinox.Cosmos</c> or <c>Propulsion</c> libraries,
-    ///   using the supplied `Newtonsoft.Json` <c>settings</c>
+    ///   using the supplied `Newtonsoft.Json` <c>settings</c>.
     /// Uses <c>up</c> and <c>down</c> functions to faciliate upconversion/downconversion
     ///   and/or surfacing metadata to the Programming Model by including it in the emitted <c>'Union</c>
     /// The Event Type Names are inferred based on either explicit `DataMember(Name=` Attributes,
     ///   or (if unspecified) the Discriminated Union Case Name on the <c>'Contract</c> type.
     /// <c>Contract</c> must be tagged with </c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.
-    static member Create<'Union,'Contract when 'Contract :> TypeShape.UnionContract.IUnionContract>
+    static member Create<'Union,'Meta,'Contract when 'Contract :> TypeShape.UnionContract.IUnionContract>
         (   /// Maps from the `TypeShape UnionConverter` 'Contract case the event has been mapped to (with the raw event data as context)
             /// to the representation (typically a Discrimninated Union) that is to be represented to the programming model
-            up : FsCodec.IEvent<byte[]> * 'Contract -> 'Union,
+            up : FsCodec.IIndexedEvent<byte[]> * 'Contract -> 'Union,
             /// Maps a fresh Event resulting from a Decision in the Domain representation type down to the `TypeShape UnionConverter` 'Contract
             /// The function is also expected to derive
-            ///   a `metadata` object which will be serialized with the same settings (if it's not `null`)
+            ///   a `metadata` object that will be serialized with the same settings (if it's not <c>None</c>)
             ///   and an Event Creation `timestamp`
-            down : 'Union -> 'Contract * obj * DateTimeOffset,
+            down : 'Union -> 'Contract * 'Meta option * DateTimeOffset option,
             /// Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to same as `Settings.Create()`<
             ?settings,
             /// Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them
@@ -84,9 +84,10 @@ type Codec private () =
                 allowNullaryCases=not (defaultArg rejectNullaryCases false))
         { new FsCodec.IUnionEncoder<'Union,byte[]> with
             member __.Encode value =
-                let (evt, meta : obj, timestamp) = down value
-                let (enc, metaUtf8) = dataCodec.Encode evt, bytesEncoder.Encode meta
-                FsCodec.Core.EventData.Create(enc.CaseName, enc.Payload, metaUtf8, timestamp) :> _
+                let (evt, meta : 'Meta option, timestamp : DateTimeOffset option) = down value
+                let enc = dataCodec.Encode evt
+                let metaUtf8 = meta |> Option.map bytesEncoder.Encode<'Meta>
+                FsCodec.Core.EventData.Create(enc.CaseName, enc.Payload, meta=defaultArg metaUtf8 null, ?timestamp = timestamp) :> _
             member __.TryDecode encoded =
                 let evt = dataCodec.TryDecode { CaseName = encoded.EventType; Payload = encoded.Data }
                 match evt with None -> None | Some e -> (encoded,e) |> up |> Some }
@@ -98,8 +99,9 @@ type Codec private () =
     /// <c>'Union</c? must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.
     static member Create<'Union when 'Union :> TypeShape.UnionContract.IUnionContract>
         (   // Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to same as `Settings.Create()`<
+            [<Optional;DefaultParameterValue(null)>]
             ?settings,
             /// Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them
             [<Optional;DefaultParameterValue(null)>]?rejectNullaryCases)
         : FsCodec.IUnionEncoder<'Union,byte[]> =
-        Codec.Create(up=snd, down=(fun evt -> evt,null,DateTimeOffset.UtcNow), ?settings=settings, ?rejectNullaryCases=rejectNullaryCases)
+        Codec.Create(up=snd, down=(fun evt -> evt,None,None), ?settings=settings, ?rejectNullaryCases=rejectNullaryCases)

--- a/src/FsCodec.NewtonsoftJson/Codec.fs
+++ b/src/FsCodec.NewtonsoftJson/Codec.fs
@@ -55,38 +55,49 @@ type Codec private () =
     static let defaultSettings = lazy Settings.Create()
 
     /// Generate a codec suitable for use with <c>Equinox.EventStore</c>, <c>Equinox.Cosmos</c> or <c>Propulsion</c> libraries,
-    ///   using the supplied `Newtonsoft.Json` <c>settings</c>.
+    ///   using the supplied `Newtonsoft.Json` <c>settings</c>
+    /// Uses <c>up</c> and <c>down</c> functions to faciliate upconversion/downconversion
+    ///   and/or surfacing metadata to the Programming Model by including it in the emitted <c>'Union</c>
     /// The Event Type Names are inferred based on either explicit `DataMember(Name=` Attributes,
-    ///   or (if unspecified) the Discriminated Union Case Name
-    /// The Union must be tagged with `interface TypeShape.UnionContract.IUnionContract` to signify this scheme applies.
-    /// See https://github.com/eiriktsarpalis/TypeShape/blob/master/tests/TypeShape.Tests/UnionContractTests.fs for example usage.
-    static member Create<'Union when 'Union :> TypeShape.UnionContract.IUnionContract>
-        (   /// Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to same as `Settings.Create()`<
+    ///   or (if unspecified) the Discriminated Union Case Name on the <c>'Contract</c> type.
+    /// <c>Contract</c> must be tagged with </c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.
+    static member Create<'Union,'Contract when 'Contract :> TypeShape.UnionContract.IUnionContract>
+        (   /// Maps from the `TypeShape UnionConverter` 'Contract case the event has been mapped to (with the raw event data as context)
+            /// to the representation (typically a Discrimninated Union) that is to be represented to the programming model
+            up : FsCodec.IEvent<byte[]> * 'Contract -> 'Union,
+            /// Maps a fresh Event resulting from a Decision in the Domain representation type down to the `TypeShape UnionConverter` 'Contract
+            /// The function is also expected to derive a `metadata` (which may be `null`) and an Event Creation TimeStamp
+            down : 'Union -> 'Contract * byte[] * DateTimeOffset,
+            /// Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to same as `Settings.Create()`<
             ?settings,
-            /// Generate a metadata object to serialize from a given 'value
-            [<Optional;DefaultParameterValue(null)>]?mapMeta : 'Union -> obj,
-            /// Provides a function that can be used to determine the creation time for a given event 'value
-            [<Optional;DefaultParameterValue(null)>]?genTimestamp : 'Union -> DateTimeOffset,
-            /// Fail encoder generation if union contains nullary cases. Defaults to <c>true</c>.<
-            [<Optional;DefaultParameterValue(null)>]?allowNullaryCases)
+            /// Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them
+            [<Optional;DefaultParameterValue(null)>]?rejectNullaryCases)
         : FsCodec.IUnionEncoder<'Union,byte[]> =
         let settings = match settings with Some x -> x | None -> defaultSettings.Value
         let bytesEncoder : TypeShape.UnionContract.IEncoder<_> = new Core.BytesEncoder(settings) :> _
         let dataCodec =
-            TypeShape.UnionContract.UnionContractEncoder.Create<'Union,byte[]>(
+            TypeShape.UnionContract.UnionContractEncoder.Create<'Contract,byte[]>(
                 bytesEncoder,
                 requireRecordFields=true, // See JsonConverterTests - roundtripping UTF-8 correctly with Json.net is painful so for now we lock up the dragons
-                ?allowNullaryCases=allowNullaryCases)
-        let (metaf, timestampf) =
-            match mapMeta,genTimestamp with
-            | Some mf, Some gts -> (fun value -> bytesEncoder.Encode (mf value)), (fun value -> Some (gts value))
-            | Some mf, None -> (fun value -> bytesEncoder.Encode (mf value)), (fun _ -> None)
-            | None, Some gts -> (fun _ -> null), (fun value -> Some (gts value))
-            | None, None -> (fun _ -> null), (fun _ -> None)
+                allowNullaryCases=not (defaultArg rejectNullaryCases false))
         { new FsCodec.IUnionEncoder<'Union,byte[]> with
             member __.Encode value =
-                let enc = dataCodec.Encode value
-                let (meta, timestamp) = metaf value, timestampf value
-                FsCodec.Core.EventData.Create(enc.CaseName, enc.Payload, meta, ?timestamp=timestamp) :> _
+                let (evt, meta, timestamp) = down value
+                let enc = dataCodec.Encode evt
+                FsCodec.Core.EventData.Create(enc.CaseName, enc.Payload, meta, timestamp) :> _
             member __.TryDecode encoded =
-                dataCodec.TryDecode { CaseName = encoded.EventType; Payload = encoded.Data } }
+                let evt = dataCodec.TryDecode { CaseName = encoded.EventType; Payload = encoded.Data }
+                match evt with None -> None | Some e -> (encoded,e) |> up |> Some }
+
+    /// Generate a codec suitable for use with <c>Equinox.EventStore</c>, <c>Equinox.Cosmos</c> or <c>Propulsion</c> libraries,
+    ///   using the supplied `Newtonsoft.Json` <c>settings</c>.
+    /// The Event Type Names are inferred based on either explicit `DataMember(Name=` Attributes,
+    ///   or (if unspecified) the Discriminated Union Case Name
+    /// <c>'Union</c? must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.
+    static member Create<'Union when 'Union :> TypeShape.UnionContract.IUnionContract>
+        (   // Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to same as `Settings.Create()`<
+            ?settings,
+            /// Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them
+            [<Optional;DefaultParameterValue(null)>]?rejectNullaryCases)
+        : FsCodec.IUnionEncoder<'Union,byte[]> =
+        Codec.Create(up=snd, down=(fun evt -> evt,null,DateTimeOffset.UtcNow), ?settings=settings, ?rejectNullaryCases=rejectNullaryCases)

--- a/src/FsCodec/FsCodec.fs
+++ b/src/FsCodec/FsCodec.fs
@@ -15,24 +15,20 @@ type IEvent<'Format> =
     /// </remarks>
     abstract member Timestamp : System.DateTimeOffset
 
-namespace FsCodec.Core
-
 /// Represents a Domain Event or Unfold, together with it's Index in the event sequence
 type IIndexedEvent<'Format> =
-    inherit FsCodec.IEvent<'Format>
+    inherit IEvent<'Format>
     /// The index into the event sequence of this event
     abstract member Index : int64
     /// Indicates this is not a Domain Event, but actually an Unfolded Event based on the state inferred from the events up to `Index`
     abstract member IsUnfold : bool
-
-namespace FsCodec
 
 /// Defines a contract interpreter for a Discriminated Union representing a set of events borne by a stream
 type IUnionEncoder<'Union, 'Format> =
     /// Encodes a union instance into a decoded representation
     abstract Encode : value: 'Union -> IEvent<'Format>
     /// Decodes a formatted representation into a union instance. Does not throw exception on format mismatches
-    abstract TryDecode : encoded: IEvent<'Format> -> 'Union option
+    abstract TryDecode : encoded: IIndexedEvent<'Format> -> 'Union option
 
 namespace FsCodec.Core
 
@@ -50,7 +46,7 @@ type EventData<'Format> =
 /// An Event that's been read from a Store
 [<NoComparison; NoEquality>]
 type IndexedEventData<'Format>(index, isUnfold, eventType, data, metadata, timestamp) =
-    interface FsCodec.Core.IIndexedEvent<'Format> with
+    interface FsCodec.IIndexedEvent<'Format> with
         member __.Index = index
         member __.IsUnfold = isUnfold
         member __.EventType = eventType

--- a/tests/FsCodec.NewtonsoftJson.Tests/VerbatimUtf8ConverterTests.fs
+++ b/tests/FsCodec.NewtonsoftJson.Tests/VerbatimUtf8ConverterTests.fs
@@ -73,7 +73,7 @@ type VerbatimUtf8Tests() =
                 e = [| { t = DateTimeOffset.MinValue; c = encoded.EventType; d = encoded.Data; m = null } |] }
         let ser = JsonConvert.SerializeObject(e, defaultSettings)
         let des = JsonConvert.DeserializeObject<Batch>(ser, defaultSettings)
-        let loaded = FsCodec.Core.EventData.Create(des.e.[0].c,des.e.[0].d)
+        let loaded = FsCodec.Core.IndexedEventData(-1L, false, des.e.[0].c, des.e.[0].d, null, DateTimeOffset.MinValue)
         let decoded = uEncoder.TryDecode loaded |> Option.get
         x =! decoded
 
@@ -82,7 +82,8 @@ type VerbatimUtf8Tests() =
     let [<Fact>] ``Codec does not fall prey to Date-strings being mutilated`` () =
         let x = ES { embed = "2016-03-31T07:02:00+07:00" }
         let encoded = uEncoder.Encode x
-        let decoded = uEncoder.TryDecode encoded |> Option.get
+        let adapted = FsCodec.Core.IndexedEventData(-1L, false, encoded.EventType, encoded.Data, encoded.Meta, encoded.Timestamp)
+        let decoded = uEncoder.TryDecode adapted |> Option.get
         test <@ x = decoded @>
 
     //// NB while this aspect works, we don't support it as it gets messy when you then use the VerbatimUtf8Converter


### PR DESCRIPTION
This PR changes a tentative overload of `FsCodec.NewtonsoftJson.Codec.Create` which addresses a specific case cited by @rajivhost with a more general mechanism in line with the needs discussed in the context of @ameier's https://github.com/ameier38/equinox-tutorial
- [x] enables overriding of `metadata` and `timestamp` during `IEvent` generation (as per previous API - this is an intentional breaking change with limited scope at this point)
- [x] enable surfacing of information based on `IEvent`'s `Meta`, `Timestamp` to the programming model to the programming model for events being loaded