### PR TITLE
EventData, IndexedEventData consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- Removed comparison support from `EventData` [#19](https://github.com/jet/FsCodec/pull/19)
+- Changed `IndexedEventData` ctor to `.Create` and aligned with `EventData` [#19](https://github.com/jet/FsCodec/pull/19)
+
 ### Removed
 ### Fixed
 

--- a/src/FsCodec/FsCodec.fs
+++ b/src/FsCodec/FsCodec.fs
@@ -35,28 +35,26 @@ namespace FsCodec.Core
 open System
 
 /// An Event about to be written, see IEvent for further information
-type EventData<'Format> =
-    { eventType : string; data : 'Format; meta : 'Format; timestamp : DateTimeOffset }
+[<NoComparison; NoEquality>]
+type EventData<'Format> private (eventType, data, meta, timestamp) =
+    static member Create(eventType, data, ?meta, ?timestamp) =
+        EventData(eventType, data, defaultArg meta Unchecked.defaultof<_>, match timestamp with Some ts -> ts | None -> DateTimeOffset.UtcNow)
     interface FsCodec.IEvent<'Format> with
-        member __.EventType = __.eventType
-        member __.Data = __.data
-        member __.Meta = __.meta
-        member __.Timestamp = __.timestamp
+        member __.EventType = eventType
+        member __.Data = data
+        member __.Meta = meta
+        member __.Timestamp = timestamp
 
 /// An Event that's been read from a Store
 [<NoComparison; NoEquality>]
-type IndexedEventData<'Format>(index, isUnfold, eventType, data, metadata, timestamp) =
+type IndexedEventData<'Format> private (index, isUnfold, eventType, data, meta, timestamp) =
+    static member Create(index, eventType, data, ?meta, ?timestamp, ?isUnfold) =
+        let isUnfold, meta = defaultArg isUnfold false, defaultArg meta Unchecked.defaultof<_>
+        IndexedEventData(index, isUnfold, eventType, data, meta, match timestamp with Some ts -> ts | None -> DateTimeOffset.UtcNow)
     interface FsCodec.IIndexedEvent<'Format> with
         member __.Index = index
         member __.IsUnfold = isUnfold
         member __.EventType = eventType
         member __.Data = data
-        member __.Meta = metadata
+        member __.Meta = meta
         member __.Timestamp = timestamp
-
-type EventData =
-    static member Create(eventType, data, ?meta, ?timestamp) =
-        {   eventType = eventType
-            data = data
-            meta = defaultArg meta null
-            timestamp = match timestamp with Some ts -> ts | None -> DateTimeOffset.UtcNow }

--- a/tests/FsCodec.NewtonsoftJson.Tests/VerbatimUtf8ConverterTests.fs
+++ b/tests/FsCodec.NewtonsoftJson.Tests/VerbatimUtf8ConverterTests.fs
@@ -75,7 +75,7 @@ type VerbatimUtf8Tests() =
                 e = [| { t = DateTimeOffset.MinValue; c = encoded.EventType; d = encoded.Data; m = null } |] }
         let ser = JsonConvert.SerializeObject(e, defaultSettings)
         let des = JsonConvert.DeserializeObject<Batch>(ser, defaultSettings)
-        let loaded = FsCodec.Core.IndexedEventData(-1L, false, des.e.[0].c, des.e.[0].d, null, DateTimeOffset.MinValue)
+        let loaded = FsCodec.Core.IndexedEventData.Create(-1L, des.e.[0].c, des.e.[0].d)
         let decoded = uEncoder.TryDecode loaded |> Option.get
         x =! decoded
 
@@ -84,7 +84,7 @@ type VerbatimUtf8Tests() =
     let [<Fact>] ``Codec does not fall prey to Date-strings being mutilated`` () =
         let x = ES { embed = "2016-03-31T07:02:00+07:00" }
         let encoded = uEncoder.Encode x
-        let adapted = FsCodec.Core.IndexedEventData(-1L, false, encoded.EventType, encoded.Data, encoded.Meta, encoded.Timestamp)
+        let adapted = FsCodec.Core.IndexedEventData.Create(-1L, encoded.EventType, encoded.Data, encoded.Meta, encoded.Timestamp)
         let decoded = uEncoder.TryDecode adapted |> Option.get
         test <@ x = decoded @>
 


### PR DESCRIPTION
Cleanup, see #18. Will have small knock-on impacts in tests in Propulsion and Equinox, but so be it 
- [x] make `IndexedEventData.new` align with `EventData.Create`
- [x] consider hiding `EventData` record and/or its equality or comparison facilities