### PR TITLE
Rename IEvent, IIndexedEvent to IEventData, ITimelineEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 - Removed comparison support from `EventData` [#19](https://github.com/jet/FsCodec/pull/19)
 - Changed `IndexedEventData` ctor to `.Create` and aligned with `EventData` [#19](https://github.com/jet/FsCodec/pull/19)
+- Renamed `IEvent` to `IEventData` (to avoid clashes with `FSharp.Control.IEvent`) [#20](https://github.com/jet/FsCodec/pull/20)
+- Renamed `IIndexedEvent` to `ITimelineEvent` (to avoid clashes with `FSharp.Control.IEvent`) [#20](https://github.com/jet/FsCodec/pull/20)
+- Renamed `IndexedEventData` to `TimelineEvent` [#20](https://github.com/jet/FsCodec/pull/20)
 
 ### Removed
 ### Fixed

--- a/src/FsCodec.NewtonsoftJson/Codec.fs
+++ b/src/FsCodec.NewtonsoftJson/Codec.fs
@@ -62,7 +62,7 @@ type Codec private () =
     static member Create<'Union,'Meta,'Contract when 'Contract :> TypeShape.UnionContract.IUnionContract>
         (   /// Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
             /// to the representation (typically a Discriminated Union) that is to be presented to the programming model.
-            up : FsCodec.IIndexedEvent<byte[]> * 'Contract -> 'Union,
+            up : FsCodec.ITimelineEvent<byte[]> * 'Contract -> 'Union,
             /// Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
             /// The function is also expected to derive
             ///   a <c>meta</c> object that will be serialized with the same settings (if it's not <c>None</c>)

--- a/src/FsCodec/FsCodec.fs
+++ b/src/FsCodec/FsCodec.fs
@@ -1,6 +1,6 @@
 namespace FsCodec
 
-/// Common form for either a Domain Event or an Unfolded Event
+/// Common form for either a Domain Event or an Unfolded Event, without any context regarding its place in the timeline of events
 type IEventData<'Format> =
     /// The Event Type, used to drive deserialization
     abstract member EventType : string
@@ -15,26 +15,26 @@ type IEventData<'Format> =
     /// </remarks>
     abstract member Timestamp : System.DateTimeOffset
 
-/// Represents a Domain Event or Unfold, together with it's Index in the event sequence
-type IIndexedEvent<'Format> =
+/// Represents a Domain Event or Unfold, together with it's 0-based <c>Index</c> in the event sequence
+type ITimelineEvent<'Format> =
     inherit IEventData<'Format>
-    /// The index into the event sequence of this event
+    /// The 0-based index into the event sequence of this Event
     abstract member Index : int64
-    /// Indicates this is not a Domain Event, but actually an Unfolded Event based on the state inferred from the events up to `Index`
+    /// Indicates this is not a true Domain Event, but actually an Unfolded Event based on the State inferred from the Events up to and including that at <c>Index</c>
     abstract member IsUnfold : bool
 
 /// Defines a contract interpreter for a Discriminated Union representing a set of events borne by a stream
 type IUnionEncoder<'Union, 'Format> =
     /// Encodes a union instance into a decoded representation
     abstract Encode : value: 'Union -> IEventData<'Format>
-    /// Decodes a formatted representation into a union instance. Does not throw exception on format mismatches
-    abstract TryDecode : encoded: IIndexedEvent<'Format> -> 'Union option
+    /// Decodes a formatted representation into a <c>'Union<c> instance. Does not throw exception on format mismatches
+    abstract TryDecode : encoded: ITimelineEvent<'Format> -> 'Union option
 
 namespace FsCodec.Core
 
 open System
 
-/// An Event about to be written, see IEvent for further information
+/// An Event about to be written, see <c>IEventData<c> for further information
 [<NoComparison; NoEquality>]
 type EventData<'Format> private (eventType, data, meta, timestamp) =
     static member Create(eventType, data, ?meta, ?timestamp) =
@@ -45,13 +45,13 @@ type EventData<'Format> private (eventType, data, meta, timestamp) =
         member __.Meta = meta
         member __.Timestamp = timestamp
 
-/// An Event that's been read from a Store
+/// An Event or Unfold that's been read from a Store and hence has a defined <c>Index</c> on the Event Timeline
 [<NoComparison; NoEquality>]
-type IndexedEventData<'Format> private (index, isUnfold, eventType, data, meta, timestamp) =
+type TimelineEvent<'Format> private (index, isUnfold, eventType, data, meta, timestamp) =
     static member Create(index, eventType, data, ?meta, ?timestamp, ?isUnfold) =
         let isUnfold, meta = defaultArg isUnfold false, defaultArg meta Unchecked.defaultof<_>
-        IndexedEventData(index, isUnfold, eventType, data, meta, match timestamp with Some ts -> ts | None -> DateTimeOffset.UtcNow)
-    interface FsCodec.IIndexedEvent<'Format> with
+        TimelineEvent(index, isUnfold, eventType, data, meta, match timestamp with Some ts -> ts | None -> DateTimeOffset.UtcNow)
+    interface FsCodec.ITimelineEvent<'Format> with
         member __.Index = index
         member __.IsUnfold = isUnfold
         member __.EventType = eventType

--- a/src/FsCodec/FsCodec.fs
+++ b/src/FsCodec/FsCodec.fs
@@ -1,7 +1,7 @@
 namespace FsCodec
 
 /// Common form for either a Domain Event or an Unfolded Event
-type IEvent<'Format> =
+type IEventData<'Format> =
     /// The Event Type, used to drive deserialization
     abstract member EventType : string
     /// Event body, as UTF-8 encoded json ready to be injected into the Store
@@ -17,7 +17,7 @@ type IEvent<'Format> =
 
 /// Represents a Domain Event or Unfold, together with it's Index in the event sequence
 type IIndexedEvent<'Format> =
-    inherit IEvent<'Format>
+    inherit IEventData<'Format>
     /// The index into the event sequence of this event
     abstract member Index : int64
     /// Indicates this is not a Domain Event, but actually an Unfolded Event based on the state inferred from the events up to `Index`
@@ -26,7 +26,7 @@ type IIndexedEvent<'Format> =
 /// Defines a contract interpreter for a Discriminated Union representing a set of events borne by a stream
 type IUnionEncoder<'Union, 'Format> =
     /// Encodes a union instance into a decoded representation
-    abstract Encode : value: 'Union -> IEvent<'Format>
+    abstract Encode : value: 'Union -> IEventData<'Format>
     /// Decodes a formatted representation into a union instance. Does not throw exception on format mismatches
     abstract TryDecode : encoded: IIndexedEvent<'Format> -> 'Union option
 
@@ -39,7 +39,7 @@ open System
 type EventData<'Format> private (eventType, data, meta, timestamp) =
     static member Create(eventType, data, ?meta, ?timestamp) =
         EventData(eventType, data, defaultArg meta Unchecked.defaultof<_>, match timestamp with Some ts -> ts | None -> DateTimeOffset.UtcNow)
-    interface FsCodec.IEvent<'Format> with
+    interface FsCodec.IEventData<'Format> with
         member __.EventType = eventType
         member __.Data = data
         member __.Meta = meta

--- a/tests/FsCodec.NewtonsoftJson.Tests/VerbatimUtf8ConverterTests.fs
+++ b/tests/FsCodec.NewtonsoftJson.Tests/VerbatimUtf8ConverterTests.fs
@@ -75,7 +75,7 @@ type VerbatimUtf8Tests() =
                 e = [| { t = DateTimeOffset.MinValue; c = encoded.EventType; d = encoded.Data; m = null } |] }
         let ser = JsonConvert.SerializeObject(e, defaultSettings)
         let des = JsonConvert.DeserializeObject<Batch>(ser, defaultSettings)
-        let loaded = FsCodec.Core.IndexedEventData.Create(-1L, des.e.[0].c, des.e.[0].d)
+        let loaded = FsCodec.Core.TimelineEvent.Create(-1L, des.e.[0].c, des.e.[0].d)
         let decoded = uEncoder.TryDecode loaded |> Option.get
         x =! decoded
 
@@ -84,7 +84,7 @@ type VerbatimUtf8Tests() =
     let [<Fact>] ``Codec does not fall prey to Date-strings being mutilated`` () =
         let x = ES { embed = "2016-03-31T07:02:00+07:00" }
         let encoded = uEncoder.Encode x
-        let adapted = FsCodec.Core.IndexedEventData.Create(-1L, encoded.EventType, encoded.Data, encoded.Meta, encoded.Timestamp)
+        let adapted = FsCodec.Core.TimelineEvent.Create(-1L, encoded.EventType, encoded.Data, encoded.Meta, encoded.Timestamp)
         let decoded = uEncoder.TryDecode adapted |> Option.get
         test <@ x = decoded @>
 


### PR DESCRIPTION
See #18 
- `IEvent` can cause very time-consuming confusion due to the fact that `FSharp.Control.IEvent` is implicity in scope in F# code by default (ask me how I know)
- `IIndexedEvent` never made me happy

Improvements on either name are welcome!

CC @rajivhost intending to feed usage of this into Equinox and Propulsion soon, assuming no objections