### PR TITLE
Provide support for derivation of CorrelationId / CausationId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- Defined `CorrelationId` and `CausationId` properties for `IEventData` [#21](https://github.com/jet/FsCodec/pull/21)
+- Added `context : 'Context option` param to `IUnionEncoder.Encode`, enabling `down` to enrich events with `correlationId` and `causationId` values without reference to external state [#21](https://github.com/jet/FsCodec/pull/21)
+
 ### Changed
 
 - Removed comparison support from `EventData` [#19](https://github.com/jet/FsCodec/pull/19)

--- a/src/FsCodec.NewtonsoftJson/Codec.fs
+++ b/src/FsCodec.NewtonsoftJson/Codec.fs
@@ -82,10 +82,10 @@ type Codec private () =
                 allowNullaryCases=not (defaultArg rejectNullaryCases false))
         { new FsCodec.IUnionEncoder<'Union,byte[],'Context> with
             member __.Encode(context,value) =
-                let (evt, meta : 'Meta option, corr, cause, timestamp : DateTimeOffset option) = down context value
+                let (evt, meta : 'Meta option, correlationId, causationId, timestamp : DateTimeOffset option) = down context value
                 let enc = dataCodec.Encode evt
                 let metaUtf8 = meta |> Option.map bytesEncoder.Encode<'Meta>
-                FsCodec.Core.EventData.Create(enc.CaseName, enc.Payload, meta=defaultArg metaUtf8 null, ?timestamp = timestamp) :> _
+                FsCodec.Core.EventData.Create(enc.CaseName, enc.Payload, defaultArg metaUtf8 null, correlationId, causationId, ?timestamp=timestamp) :> _
             member __.TryDecode encoded =
                 let evt = dataCodec.TryDecode { CaseName = encoded.EventType; Payload = encoded.Data }
                 match evt with None -> None | Some e -> (encoded,e) |> up |> Some }

--- a/src/FsCodec/FsCodec.fs
+++ b/src/FsCodec/FsCodec.fs
@@ -14,7 +14,9 @@ type IEventData<'Format> =
     /// - For Cosmos, the value is not exposed where the event `IsUnfold`.
     /// </remarks>
     abstract member Timestamp : System.DateTimeOffset
+    /// The Correlation Id associated with the flow that generated this event. Can be `null`
     abstract member CorrelationId : string
+    /// The Causation Id associated with the flow that generated this event. Can be `null`
     abstract member CausationId : string
 
 /// Represents a Domain Event or Unfold, together with it's 0-based <c>Index</c> in the event sequence
@@ -40,7 +42,8 @@ open System
 [<NoComparison; NoEquality>]
 type EventData<'Format> private (eventType, data, meta, correlationId, causationId, timestamp) =
     static member Create(eventType, data, ?meta, ?correlationId, ?causationId, ?timestamp) =
-        EventData(eventType, data, defaultArg meta Unchecked.defaultof<_>, defaultArg correlationId null, defaultArg causationId null, match timestamp with Some ts -> ts | None -> DateTimeOffset.UtcNow)
+        let meta, correlationId, causationId = defaultArg meta Unchecked.defaultof<_>, defaultArg correlationId null, defaultArg causationId null
+        EventData(eventType, data, meta, correlationId, causationId, match timestamp with Some ts -> ts | None -> DateTimeOffset.UtcNow)
     interface FsCodec.IEventData<'Format> with
         member __.EventType = eventType
         member __.Data = data
@@ -54,8 +57,8 @@ type EventData<'Format> private (eventType, data, meta, correlationId, causation
 type TimelineEvent<'Format> private (index, isUnfold, eventType, data, meta, correlationId, causationId, timestamp) =
     static member Create(index, eventType, data, ?meta, ?correlationId, ?causationId, ?timestamp, ?isUnfold) =
         let isUnfold, meta = defaultArg isUnfold false, defaultArg meta Unchecked.defaultof<_>
-        let corr, cause = defaultArg correlationId null, defaultArg causationId null
-        TimelineEvent(index, isUnfold, eventType, data, meta, corr, cause, match timestamp with Some ts -> ts | None -> DateTimeOffset.UtcNow)
+        let correlationId, causationId = defaultArg correlationId null, defaultArg causationId null
+        TimelineEvent(index, isUnfold, eventType, data, meta, correlationId, causationId, match timestamp with Some ts -> ts | None -> DateTimeOffset.UtcNow)
     interface FsCodec.ITimelineEvent<'Format> with
         member __.Index = index
         member __.IsUnfold = isUnfold

--- a/tests/FsCodec.NewtonsoftJson.Tests/VerbatimUtf8ConverterTests.fs
+++ b/tests/FsCodec.NewtonsoftJson.Tests/VerbatimUtf8ConverterTests.fs
@@ -59,7 +59,7 @@ type VerbatimUtf8Tests() =
 
     [<Fact>]
     let ``encodes correctly`` () =
-        let encoded = unionEncoder.Encode(A { embed = "\"" })
+        let encoded = unionEncoder.Encode(None, A { embed = "\"" })
         let e : Batch =
             {   p = "streamName"; id = string 0; i = -1L; n = -1L; _etag = null
                 e = [| { t = DateTimeOffset.MinValue; c = encoded.EventType; d = encoded.Data; m = null } |] }
@@ -69,7 +69,7 @@ type VerbatimUtf8Tests() =
     let uEncoder = Codec.Create<U>(defaultSettings)
 
     let [<Property(MaxTest=100)>] ``round-trips diverse bodies correctly`` (x: U) =
-        let encoded = uEncoder.Encode x
+        let encoded = uEncoder.Encode(None,x)
         let e : Batch =
             {   p = "streamName"; id = string 0; i = -1L; n = -1L; _etag = null
                 e = [| { t = DateTimeOffset.MinValue; c = encoded.EventType; d = encoded.Data; m = null } |] }
@@ -83,8 +83,8 @@ type VerbatimUtf8Tests() =
     // https://github.com/JamesNK/Newtonsoft.Json/issues/862 // doesnt apply to this case
     let [<Fact>] ``Codec does not fall prey to Date-strings being mutilated`` () =
         let x = ES { embed = "2016-03-31T07:02:00+07:00" }
-        let encoded = uEncoder.Encode x
-        let adapted = FsCodec.Core.TimelineEvent.Create(-1L, encoded.EventType, encoded.Data, encoded.Meta, encoded.Timestamp)
+        let encoded = uEncoder.Encode(None,x)
+        let adapted = FsCodec.Core.TimelineEvent.Create(-1L, encoded.EventType, encoded.Data, encoded.Meta, timestamp = encoded.Timestamp)
         let decoded = uEncoder.TryDecode adapted |> Option.get
         test <@ x = decoded @>
 


### PR DESCRIPTION
While the current codec overloads allow one to supply a `down` function which can add contextual information to enrich an event, the codec needs to be generated freshly each time, or else it needs to grab values from some global context out of band.

This PR adds:
- well known `CorrelationId` and `CausationId` members on all Event Data interfaces
- `IUnionEncode.Encode` now admits a `'Context option` argument, which is made available to the `down` function in order to be able to generate same

Closes #21 