### PR TITLE
Add mapCausation overload, restore rc2 Codec overloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
+<a name="1.1.0"></a>
+## [1.1.0] - 2019-09-19
+
+### Added
+
+- Polished overloads of `Codec.Create` and `NewtonsoftJson.Codec.Create` to be more navigable, and usable from C# [#23](https://github.com/jet/FsCodec/pull/23)
+
 <a name="1.0.0"></a>
 ## [1.0.0] - 2019-09-17
 

--- a/src/FsCodec.NewtonsoftJson/Codec.fs
+++ b/src/FsCodec.NewtonsoftJson/Codec.fs
@@ -47,7 +47,7 @@ module Core =
                 use jsonReader = Utf8BytesEncoder.makeJsonReader ms
                 serializer.Deserialize<'T>(jsonReader)
 
-// Provides Codecs that render to a UTF-8 array suitable for storage in Event Stores based using <c>Newtonsoft.Json</c> and the conventions implied by using
+/// Provides Codecs that render to a UTF-8 array suitable for storage in Event Stores based using <c>Newtonsoft.Json</c> and the conventions implied by using
 /// <c>TypeShape.UnionContract.UnionContractEncoder</c> - if you need full control and/or have have your own codecs, see <c>FsCodec.Codec.Create</c> instead
 /// See <a href=""https://github.com/eiriktsarpalis/TypeShape/blob/master/tests/TypeShape.Tests/UnionContractTests.fs"></a> for example usage.
 type Codec private () =

--- a/src/FsCodec/Codec.fs
+++ b/src/FsCodec/Codec.fs
@@ -12,16 +12,39 @@ type Codec =
     static member private Create<'Union,'Context>
         (   /// Maps a 'Union to an Event Type Name with UTF-8 arrays representing the <c>Data</c> and <c>Meta</c> together with the correlationId, causationId and timestamp.
             encode : 'Context option -> 'Union -> string * byte[] * byte[] * string * string * System.DateTimeOffset option,
-            /// Attempts to map from an Event Type Name and UTF-8 arrays representing the <c>Data</c> and <c>Meta</c>
-            ///   to a <c>'Union</c> case, or <c>None</c> if not mappable.
-            tryDecode : string * byte[] -> byte[] * string * string * DateTimeOffset -> 'Union option)
+            /// Attempts to map from an Event's Data to a <c>'Union</c> case, or <c>None</c> if not mappable.
+            tryDecode : ITimelineEvent<byte[]> -> 'Union option)
         : IUnionEncoder<'Union, byte[], 'Context> =
         { new IUnionEncoder<'Union, byte[], 'Context> with
             member __.Encode(context, event) =
                 let eventType, data, metadata, correlationId, causationId, timestamp = encode context event
                 Core.EventData.Create(eventType, data, metadata, correlationId, causationId, ?timestamp=timestamp) :> _
             member __.TryDecode ie =
-                tryDecode (ie.EventType, ie.Data) (ie.Meta, ie.CorrelationId, ie.CausationId, ie.Timestamp) }
+                tryDecode ie }
+
+    /// Generate a <code>IUnionEncoder</code> Codec suitable using the supplied pair of <c>encode</c> and <c>tryDecode</code> functions.
+    /// <c>mapCausation</c> provides correlation/causationId mapping
+    static member Create<'Union,'Context>
+        (   /// Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
+            /// to the representation (typically a Discriminated Union) that is to be presented to the programming model.
+            tryDecode : FsCodec.ITimelineEvent<byte[]> -> 'Union option,
+            /// Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
+            /// The function is also expected to derive
+            ///   a <c>meta</c> object that will be serialized with the same settings (if it's not <c>None</c>)
+            ///   and an Event Creation <c>timestamp</c>.
+            encode : 'Union -> string * byte[] * DateTimeOffset option,
+            /// Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>correlationId</c> and c) the correlationId
+            mapCausation : 'Context option -> 'Union -> byte[] * string * string,
+            /// Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Settings.Create()</c>
+            ?settings,
+            /// Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them
+            ?rejectNullaryCases)
+        : FsCodec.IUnionEncoder<'Union,byte[],'Context> =
+        let encode context e =
+            let et, d, t = encode e
+            let m, correlationId, causationId = mapCausation context e
+            et, d, m, correlationId, causationId, t
+        Codec.Create(encode,tryDecode)
 
     /// Generate a <code>IUnionEncoder</code> Codec using the supplied pair of <c>encode</c> and <c>tryDecode</code> functions.
     static member Create<'Union>
@@ -31,5 +54,5 @@ type Codec =
             tryDecode : string * byte[] -> 'Union option)
         : IUnionEncoder<'Union, byte[], obj> =
         let encode' _context value = let et, d = encode value in et, d, null, null, null, None
-        let tryDecode' (et,d) _ = tryDecode (et, d)
+        let tryDecode' (e : FsCodec.ITimelineEvent<_>) = tryDecode (e.EventType, e.Data)
         Codec.Create(encode', tryDecode')

--- a/src/FsCodec/Codec.fs
+++ b/src/FsCodec/Codec.fs
@@ -11,20 +11,20 @@ type Codec =
     // (IME, while many systems have some code touching the metadata, it's not something one typically wants to encourage)
     static member private Create<'Union,'Context>
         (   /// Maps a 'Union to an Event Type Name with UTF-8 arrays representing the <c>Data</c> and <c>Meta</c> together with the correlationId, causationId and timestamp.
-            encode : 'Context option -> 'Union -> string * byte[] * byte[] * string * string * System.DateTimeOffset option,
+            encode : 'Context option * 'Union -> string * byte[] * byte[] * string * string * System.DateTimeOffset option,
             /// Attempts to map from an Event's Data to a <c>'Union</c> case, or <c>None</c> if not mappable.
             tryDecode : ITimelineEvent<byte[]> -> 'Union option)
         : IUnionEncoder<'Union, byte[], 'Context> =
         { new IUnionEncoder<'Union, byte[], 'Context> with
-            member __.Encode(context, event) =
-                let eventType, data, metadata, correlationId, causationId, timestamp = encode context event
+            member __.Encode(context, union) =
+                let eventType, data, metadata, correlationId, causationId, timestamp = encode (context,union)
                 Core.EventData.Create(eventType, data, metadata, correlationId, causationId, ?timestamp=timestamp) :> _
-            member __.TryDecode ie =
-                tryDecode ie }
+            member __.TryDecode encoded =
+                tryDecode encoded }
 
     /// Generate a <code>IUnionEncoder</code> Codec suitable using the supplied <c>encode</c> and <c>tryDecode</code> functions to map to/from UTF8.
     /// <c>mapCausation</c> provides metadata generation and correlation/causationId mapping based on the Context passed to the encoder
-    static member Create<'Union,'Context>
+    static member Create<'Context,'Union>
         (   /// Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
             /// to the representation (typically a Discriminated Union) that is to be presented to the programming model.
             tryDecode : FsCodec.ITimelineEvent<byte[]> -> 'Union option,
@@ -34,15 +34,15 @@ type Codec =
             ///   and an Event Creation <c>timestamp</c>.
             encode : 'Union -> string * byte[] * DateTimeOffset option,
             /// Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>correlationId</c> and c) the correlationId
-            mapCausation : 'Context option -> 'Union -> byte[] * string * string,
+            mapCausation : 'Context option * 'Union -> byte[] * string * string,
             /// Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Settings.Create()</c>
             ?settings,
             /// Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them
             ?rejectNullaryCases)
         : FsCodec.IUnionEncoder<'Union,byte[],'Context> =
-        let encode context e =
-            let et, d, t = encode e
-            let m, correlationId, causationId = mapCausation context e
+        let encode (context,union) =
+            let et, d, t = encode union
+            let m, correlationId, causationId = mapCausation (context, union)
             et, d, m, correlationId, causationId, t
         Codec.Create(encode,tryDecode)
 
@@ -53,6 +53,6 @@ type Codec =
             /// Attempts to map an Event Type Name and a UTF-8 <c>Data</c> array to a <c>'Union</c> case, or <c>None</c> if not mappable.
             tryDecode : string * byte[] -> 'Union option)
         : IUnionEncoder<'Union, byte[], obj> =
-        let encode' _context value = let et, d = encode value in et, d, null, null, null, None
-        let tryDecode' (e : FsCodec.ITimelineEvent<_>) = tryDecode (e.EventType, e.Data)
+        let encode' (_context,union) = let et, d = encode union in et, d, null, null, null, None
+        let tryDecode' (encoded : FsCodec.ITimelineEvent<_>) = tryDecode (encoded.EventType,encoded.Data)
         Codec.Create(encode', tryDecode')

--- a/src/FsCodec/Codec.fs
+++ b/src/FsCodec/Codec.fs
@@ -22,8 +22,8 @@ type Codec =
             member __.TryDecode ie =
                 tryDecode ie }
 
-    /// Generate a <code>IUnionEncoder</code> Codec suitable using the supplied pair of <c>encode</c> and <c>tryDecode</code> functions.
-    /// <c>mapCausation</c> provides correlation/causationId mapping
+    /// Generate a <code>IUnionEncoder</code> Codec suitable using the supplied <c>encode</c> and <c>tryDecode</code> functions to map to/from UTF8.
+    /// <c>mapCausation</c> provides metadata generation and correlation/causationId mapping based on the Context passed to the encoder
     static member Create<'Union,'Context>
         (   /// Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
             /// to the representation (typically a Discriminated Union) that is to be presented to the programming model.


### PR DESCRIPTION
Restores function signatures that were present in `1.0.0-rc2` which were removed in `1.0.0`
Provides a clearer `FsCodec.NewtosoftJson.Codec.Create` overload with a mapCausation function to facilitate cleaner metadata management
Provides a FsCodec.Codec overload with a similar signature

cc @rajivhost