### PR TITLE
Add ITimelineEvent.Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `ITimelineEvent.Context` extension field [#30](https://github.com/jet/FsCodec/pull/30)
+
 ### Changed
 ### Removed
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ type ITimelineEvent<'Format> =
     inherit IEventData<'Format>
     /// The 0-based index into the event sequence of this Event
     abstract member Index : int64
+    /// Application-supplied context related to the origin of this event
+    abstract member Context : obj
     /// Indicates this is not a true Domain Event, but actually an Unfolded Event based on the State inferred from the Events up to and including that at <c>Index</c>
     abstract member IsUnfold : bool
 ```


### PR DESCRIPTION
- [x] I don't think it needs to be generically typed
- [x] Not intending to support/require it in V1
- Should this be called `Tag` or `Properties` instead?
- Should this also go on `IEventData`?
- 🤔 Does `context` overlap with the `context` on the encoding side ?
- 🤔 should the generic `TryDecode` function require a `'Context option` and then box that into the `IEventData`?