### PR TITLE
Remove Some null handling wart

### DIFF
--- a/tests/FsCodec.SystemTextJson.Tests/CodecTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/CodecTests.fs
@@ -39,22 +39,25 @@ let [<Property>] roundtrips value =
     let ser = FsCodec.SystemTextJson.Serdes.Serialize enveloped
 
     match embedded with
-    | x when obj.ReferenceEquals(null, x) ->
-        test <@ ser.StartsWith("""{"d":{""") @>
     | Choice1Of2 { embed = null }
-    | Choice2Of2 { embed = null; opt = None }
-    | Choice2Of2 { embed = null; opt = Some null } ->
+    | Choice2Of2 { embed = null; opt = None } ->
         test <@ ser = """{"d":{}}""" @>
+    | Choice2Of2 { embed = null; opt = Some null } ->
+        test <@ ser = """{"d":{"opt":null}}""" @>
     | Choice2Of2 { embed = null } ->
         test <@ ser.StartsWith("""{"d":{"opt":""") @>
-    | _ ->
-        test <@ ser.StartsWith("""{"d":{"embed":""") @>
-
-    match embedded with
-    | Choice2Of2 { opt = None } -> test <@ not (ser.Contains "opt") @>
-    | _ -> ()
+    | Choice2Of2 { opt = x } ->
+        test <@ ser.StartsWith """{"d":{"embed":""" && ser.Contains "opt" = Option.isSome x @>
+    | Choice1Of2 _ ->
+        test <@ ser.StartsWith """{"d":{"embed":""" && not (ser.Contains "\"opt\"") @>
 
     let des = FsCodec.SystemTextJson.Serdes.Deserialize<Envelope> ser
     let wrapped = FsCodec.Core.TimelineEvent<JsonElement>.Create(-1L, eventType, des.d)
     let decoded = eventCodec.TryDecode wrapped |> Option.get
-    test <@ value = decoded @>
+
+    let expected =
+        match value with
+        | AO ({ opt = Some null } as v) -> AO { v with opt = None }
+        | BO ({ opt = Some null } as v) -> BO { v with opt = None }
+        | x -> x
+    test <@ expected = decoded @>

--- a/tests/FsCodec.SystemTextJson.Tests/CodecTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/CodecTests.fs
@@ -30,12 +30,10 @@ let roundtrips value =
         | AO e -> "AO",Choice2Of2 e
         | B e  -> "B", Choice1Of2 e
         | BO e -> "BO",Choice2Of2 e
-    // TODO remove skip here to make it fail
-    let encoded, skip =
+    let encoded =
         match embedded with
-        | Choice1Of2 e -> elementEncoder.Encode e,false
-        | Choice2Of2 eo -> elementEncoder.Encode eo, eo.opt = Some null
-    if skip then () else
+        | Choice1Of2 e -> elementEncoder.Encode e
+        | Choice2Of2 eo -> elementEncoder.Encode eo
     let enveloped = { d = encoded }
 
     // the options should be irrelevant, but use the defaults (which would add nulls in that we don't want if it was leaking)

--- a/tests/FsCodec.SystemTextJson.Tests/CodecTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/CodecTests.fs
@@ -22,8 +22,7 @@ let eventCodec = FsCodec.SystemTextJson.Codec.Create<Union>(ignoreNullOptions)
 [<NoComparison>]
 type Envelope = { d : JsonElement }
 
-[<Property(MaxTest=1000)>]
-let roundtrips value =
+let [<Property>] roundtrips value =
     let eventType, embedded =
         match value with
         | A e  -> "A", Choice1Of2 e
@@ -32,7 +31,7 @@ let roundtrips value =
         | BO e -> "BO",Choice2Of2 e
     let encoded =
         match embedded with
-        | Choice1Of2 e -> elementEncoder.Encode e
+        | Choice1Of2 e  -> elementEncoder.Encode e
         | Choice2Of2 eo -> elementEncoder.Encode eo
     let enveloped = { d = encoded }
 


### PR DESCRIPTION
`Some null` renders as `null` atm; as evidenced by the diffs, removing that wart makes for less special cases in tests re #38