### PR TITLE
Port UnionConverter to STJ

### DIFF
--- a/src/FsCodec.SystemTextJson/JsonOptionConverter.fs
+++ b/src/FsCodec.SystemTextJson/JsonOptionConverter.fs
@@ -1,4 +1,4 @@
-namespace FsCodec.SystemTextJson.Converters
+namespace FsCodec.SystemTextJson
 
 open System
 open System.Linq.Expressions

--- a/src/FsCodec.SystemTextJson/JsonRecordConverter.fs
+++ b/src/FsCodec.SystemTextJson/JsonRecordConverter.fs
@@ -1,4 +1,4 @@
-﻿namespace FsCodec.SystemTextJson.Converters
+﻿namespace FsCodec.SystemTextJson
 
 open FSharp.Reflection
 open System

--- a/src/FsCodec.SystemTextJson/JsonSerializerElementExtensions.fs
+++ b/src/FsCodec.SystemTextJson/JsonSerializerElementExtensions.fs
@@ -7,6 +7,16 @@ open System.Text.Json
 
 [<AutoOpen>]
 module internal JsonSerializerExtensions =
+#if NETSTANDARD2_0
+    let private write (element : JsonElement )=
+        let bufferWriter = ArrayBufferWriter<byte>()
+        (
+            use jsonWriter = new Utf8JsonWriter(bufferWriter)
+            element.WriteTo(jsonWriter)
+        )
+        bufferWriter.WrittenSpan
+#endif
+
     type JsonSerializer with
         static member SerializeToElement(value: 'T, [<Optional; DefaultParameterValue(null)>] ?options: JsonSerializerOptions) =
             let span = ReadOnlySpan.op_Implicit(JsonSerializer.SerializeToUtf8Bytes(value, defaultArg options null))
@@ -14,13 +24,14 @@ module internal JsonSerializerExtensions =
 
         static member DeserializeElement<'T>(element: JsonElement, [<Optional; DefaultParameterValue(null)>] ?options: JsonSerializerOptions) =
 #if NETSTANDARD2_0
-            let json = element.GetRawText()
-            JsonSerializer.Deserialize<'T>(json, defaultArg options null)
+            JsonSerializer.Deserialize<'T>(write element, defaultArg options null)
 #else
-            let bufferWriter = ArrayBufferWriter<byte>()
-            (
-                use jsonWriter = new Utf8JsonWriter(bufferWriter)
-                element.WriteTo(jsonWriter)
-            )
-            JsonSerializer.Deserialize<'T>(bufferWriter.WrittenSpan, defaultArg options null)
+            JsonSerializer.Deserialize<'T>(element.GetRawText(), defaultArg options null)
+#endif
+
+        static member DeserializeElement(element : JsonElement, t : Type, [<Optional; DefaultParameterValue(null)>] ?options: JsonSerializerOptions) =
+#if NETSTANDARD2_0
+            JsonSerializer.Deserialize(write element, t, defaultArg options null)
+#else
+            JsonSerializer.Deserialize(element.GetRawText(), t, defaultArg options null)
 #endif

--- a/src/FsCodec.SystemTextJson/Options.fs
+++ b/src/FsCodec.SystemTextJson/Options.fs
@@ -8,8 +8,8 @@ open System.Text.Json.Serialization
 type Options private () =
 
     static let defaultConverters : JsonConverter[] =
-        [|  Converters.JsonOptionConverter()
-            Converters.JsonRecordConverter() |]
+        [|  JsonOptionConverter()
+            JsonRecordConverter() |]
 
     /// Creates a default set of serializer options used by Json serialization. When used with no args, same as `JsonSerializerOptions()`
     static member CreateDefault

--- a/src/FsCodec.SystemTextJson/Options.fs
+++ b/src/FsCodec.SystemTextJson/Options.fs
@@ -8,8 +8,7 @@ open System.Text.Json.Serialization
 type Options private () =
 
     static let defaultConverters : JsonConverter[] =
-        [|  JsonOptionConverter()
-            JsonRecordConverter() |]
+        [| JsonOptionConverter(); JsonRecordConverter() |]
 
     /// Creates a default set of serializer options used by Json serialization. When used with no args, same as `JsonSerializerOptions()`
     static member CreateDefault

--- a/src/FsCodec.SystemTextJson/TypeSafeEnumConverter.fs
+++ b/src/FsCodec.SystemTextJson/TypeSafeEnumConverter.fs
@@ -1,4 +1,4 @@
-﻿namespace FsCodec.SystemTextJson.Converters
+﻿namespace FsCodec.SystemTextJson
 
 open FsCodec.SystemTextJson
 open System

--- a/src/FsCodec.SystemTextJson/TypeSafeEnumConverter.fs
+++ b/src/FsCodec.SystemTextJson/TypeSafeEnumConverter.fs
@@ -1,5 +1,6 @@
-﻿namespace FsCodec.SystemTextJson
+﻿namespace FsCodec.SystemTextJson.Converters
 
+open FsCodec.SystemTextJson
 open System
 open System.Collections.Generic
 open System.Text.Json

--- a/src/FsCodec.SystemTextJson/UnionConverter.fs
+++ b/src/FsCodec.SystemTextJson/UnionConverter.fs
@@ -7,17 +7,32 @@ open System
 open System.Reflection
 open System.Text.Json
 
+type IUnionConverterOptions =
+    abstract member Discriminator : string with get
+    abstract member CatchAllCase : string option with get
+
 /// <summary>Use this attribute in combination with a JsonConverter/UnionConverter attribute to specify
 /// your own name for a discriminator and/or a catch-all case for a specific discriminated union.
-/// If this attribute is set, its values take precedence over the values set on the converter itself.
-/// E.g. <c>[<JsonConverter(typeof<UnionConverter>); JsonUnionConverterOptions("type")>]</c></summary>
+/// If this attribute is set, its values take precedence over the values set on the converter via its constructor.
+/// Example: <c>[<JsonConverter(typeof<UnionConverter>); JsonUnionConverterOptions("type")>]</c></summary>
 /// <remarks>Not inherited because JsonConverters don't get inherited right now.
 /// https://github.com/dotnet/runtime/issues/30427#issuecomment-610080138</remarks>
 [<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Struct, AllowMultiple = false, Inherited = false)>] 
 type JsonUnionConverterOptionsAttribute(discriminator : string) =
     inherit Attribute()
-    member _.Discriminator = discriminator
-    member val CatchAll: string = null with get, set
+        member val CatchAllCase: string = null with get, set
+    interface IUnionConverterOptions with
+        member _.Discriminator = discriminator 
+        member x.CatchAllCase = Option.ofObj x.CatchAllCase
+
+type UnionConverterOptions =
+    {
+        discriminator : string
+        catchAllCase : string option
+    }
+    interface IUnionConverterOptions with
+        member x.Discriminator = x.discriminator
+        member x.CatchAllCase = x.catchAllCase
 
 [<NoComparison; NoEquality>]
 type internal Union =
@@ -26,6 +41,7 @@ type internal Union =
         tagReader: obj -> int
         fieldReader: (obj -> obj[])[]
         caseConstructor: (obj[] -> obj)[]
+        options: IUnionConverterOptions option
     }
 
 module private Union =
@@ -39,6 +55,10 @@ module private Union =
                 tagReader = FSharpValue.PreComputeUnionTagReader(t, true)
                 fieldReader = cases |> Array.map (fun c -> FSharpValue.PreComputeUnionReader(c, true))
                 caseConstructor = cases |> Array.map (fun c -> FSharpValue.PreComputeUnionConstructor(c, true))
+                options =
+                    t.GetCustomAttributes(typeof<JsonUnionConverterOptionsAttribute>, false)
+                    |> Array.tryHead // AttributeUsage(AllowMultiple = false)
+                    |> Option.map (fun a -> a :?> IUnionConverterOptions)
             } |> Some
     let tryGetUnion : Type -> Union option = memoize _tryGetUnion
 
@@ -72,11 +92,25 @@ module private Union =
                 | true, el when el.ValueKind = JsonValueKind.Null -> null
                 | true, el -> JsonSerializer.DeserializeElement (el, fi.PropertyType, options) |]
 
-type internal UnionConverter<'T> (union : Union, discriminator : string, catchAllCase : string option) =
+type UnionConverter<'T> (converterOptions) =
     inherit Serialization.JsonConverter<'T>()
+
+    static let defaultConverterOptions = { discriminator = "case"; catchAllCase = None }
+
+    let getOptions union =
+        converterOptions :> IUnionConverterOptions
+        |> defaultArg union.options
+
+    new() = UnionConverter<'T>(defaultConverterOptions)
+    new(discriminator: string, catchAllCase: string) = // Compatibility with Newtonsoft UnionConverter constructor
+        UnionConverter<'T>({ discriminator = discriminator; catchAllCase = Option.ofObj catchAllCase})
+
+    override __.CanConvert(t) = Union.tryGetUnion t |> Option.isSome
 
     override __.Write(writer, value, options) =
         let value = box value
+        let union = Union.tryGetUnion (value.GetType()) |> Option.get
+        let unionOptions = getOptions union
         let tag = union.tagReader value
         let case = union.cases.[tag]
         let fieldValues = union.fieldReader.[tag] value
@@ -84,7 +118,7 @@ type internal UnionConverter<'T> (union : Union, discriminator : string, catchAl
 
         writer.WriteStartObject()
 
-        writer.WritePropertyName(discriminator)
+        writer.WritePropertyName(unionOptions.Discriminator)
         writer.WriteStringValue(case.Name)
 
         match fieldInfos with
@@ -112,12 +146,14 @@ type internal UnionConverter<'T> (union : Union, discriminator : string, catchAl
     override __.Read(reader, t : Type, options) =
         reader.ValidateTokenType(JsonTokenType.StartObject)
         use document = JsonDocument.ParseValue &reader
+        let union = Union.tryGetUnion t |> Option.get
+        let unionOptions = getOptions union
         let element = document.RootElement
 
         let targetCaseIndex =
-            let inputCaseNameValue = element.GetProperty discriminator |> string
+            let inputCaseNameValue = element.GetProperty unionOptions.Discriminator |> string
             let findCaseNamed x = union.cases |> Array.tryFindIndex (fun case -> case.Name = x)
-            match findCaseNamed inputCaseNameValue, catchAllCase  with
+            match findCaseNamed inputCaseNameValue, unionOptions.CatchAllCase  with
             | None, None ->
                 sprintf "No case defined for '%s', and no catchAllCase nominated for '%s' on type '%s'"
                     inputCaseNameValue typeof<UnionConverter<_>>.Name t.FullName |> invalidOp
@@ -131,30 +167,3 @@ type internal UnionConverter<'T> (union : Union, discriminator : string, catchAl
 
         let targetCaseFields, targetCaseCtor = union.cases.[targetCaseIndex].GetFields(), union.caseConstructor.[targetCaseIndex]
         targetCaseCtor (Union.mapTargetCaseArgs element options targetCaseFields) :?> 'T
-
-/// Serializes a discriminated union case with a single field that is a
-/// record by flattening the record fields to the same level as the discriminator
-type UnionConverter (defaultDiscriminator : string, defaultCatchAllCase : string option) =
-    inherit Serialization.JsonConverterFactory()
-
-    static let converterType = typedefof<UnionConverter<_>>
-
-    new() = UnionConverter("case", null)
-    new(discriminator: string, catchAllCase: string) = // Compatibility with Newtonsoft UnionConverter constructor
-        UnionConverter(discriminator, match catchAllCase with null -> None | x -> Some x)
-
-    override _.CanConvert(t) = Union.tryGetUnion t |> Option.isSome
-
-    override _.CreateConverter(t, _) =
-        let options         = t.GetCustomAttributes(typeof<JsonUnionConverterOptionsAttribute>, false)
-                            |> Array.tryHead // AttributeUsage(AllowMultiple = false)
-                            |> Option.map (fun a -> a :?> JsonUnionConverterOptionsAttribute)
-        let discriminator = options |> Option.map (fun o -> o.Discriminator)
-                            |> Option.defaultValue defaultDiscriminator
-        let catchAll      = options |> Option.map (fun o -> match o.CatchAll with null -> None | x -> Some x)
-                            |> Option.defaultValue defaultCatchAllCase
-        let union         = t |> Union.tryGetUnion |> Option.get
-
-        let converter = converterType.MakeGenericType([|t|])
-
-        downcast Activator.CreateInstance(converter, union, discriminator, catchAll)

--- a/src/FsCodec.SystemTextJson/UnionConverter.fs
+++ b/src/FsCodec.SystemTextJson/UnionConverter.fs
@@ -46,7 +46,7 @@ module private Union =
     /// Paralells F# behavior wrt how it generates a DU's underlying .NET Type
     let inline isInlinedIntoUnionItem (t : Type) =
         t = typeof<string>
-        || t.IsValueType
+        //|| t.IsValueType
         || t.IsArray
         || (t.IsGenericType
            && (typedefof<Option<_>> = t.GetGenericTypeDefinition()
@@ -60,7 +60,8 @@ module private Union =
 
     /// Prepare arguments for the Case class ctor based on the kind of case and how F# maps that to a Type
     /// and/or whether we need to let json.net step in to convert argument types
-    let mapTargetCaseArgs (element : JsonElement) options : PropertyInfo[] -> obj [] = function
+    let mapTargetCaseArgs (element : JsonElement) options (props : PropertyInfo[]) : obj [] =
+        match props with
         | [| singleCaseArg |] when propTypeRequiresConstruction singleCaseArg.PropertyType ->
             [| JsonSerializer.DeserializeElement (element, singleCaseArg.PropertyType, options) |]
         | multipleFieldsInCustomCaseType ->

--- a/src/FsCodec.SystemTextJson/UnionConverter.fs
+++ b/src/FsCodec.SystemTextJson/UnionConverter.fs
@@ -105,11 +105,11 @@ type UnionConverter<'T> (converterOptions) =
     new(discriminator: string, catchAllCase: string) = // Compatibility with Newtonsoft UnionConverter constructor
         UnionConverter<'T>({ discriminator = discriminator; catchAllCase = Option.ofObj catchAllCase})
 
-    override __.CanConvert(t) = Union.tryGetUnion t |> Option.isSome
+    override __.CanConvert(_) = Union.tryGetUnion (typeof<'T>) |> Option.isSome
 
     override __.Write(writer, value, options) =
         let value = box value
-        let union = Union.tryGetUnion (value.GetType()) |> Option.get
+        let union = Union.tryGetUnion (typeof<'T>) |> Option.get
         let unionOptions = getOptions union
         let tag = union.tagReader value
         let case = union.cases.[tag]
@@ -146,7 +146,7 @@ type UnionConverter<'T> (converterOptions) =
     override __.Read(reader, t : Type, options) =
         reader.ValidateTokenType(JsonTokenType.StartObject)
         use document = JsonDocument.ParseValue &reader
-        let union = Union.tryGetUnion t |> Option.get
+        let union = Union.tryGetUnion (typeof<'T>) |> Option.get
         let unionOptions = getOptions union
         let element = document.RootElement
 

--- a/src/FsCodec.SystemTextJson/UnionConverter.fs
+++ b/src/FsCodec.SystemTextJson/UnionConverter.fs
@@ -1,11 +1,11 @@
-﻿namespace FsCodec.SystemTextJson
+﻿namespace FsCodec.SystemTextJson.Converters
 
+open FsCodec.SystemTextJson
+open FsCodec.SystemTextJson.Core
 open FSharp.Reflection
 open System
 open System.Reflection
 open System.Text.Json
-
-open FsCodec.SystemTextJson.Core
 
 [<NoComparison; NoEquality>]
 type private Union =

--- a/src/FsCodec.SystemTextJson/UnionConverter.fs
+++ b/src/FsCodec.SystemTextJson/UnionConverter.fs
@@ -2,6 +2,8 @@
 
 open FSharp.Reflection
 open System
+open System.Reflection
+open System.Text.Json
 
 [<NoComparison; NoEquality>]
 type private Union =
@@ -25,3 +27,108 @@ module private Union =
                 caseConstructor = cases |> Array.map (fun c -> FSharpValue.PreComputeUnionConstructor(c, true))
             } |> Some
     let tryGetUnion : Type -> Union option = memoize _tryGetUnion
+
+
+    /// Paralells F# behavior wrt how it generates a DU's underlying .NET Type
+    let inline isInlinedIntoUnionItem (t : Type) =
+        t = typeof<string>
+        || t.IsValueType
+        || t.IsArray
+        || (t.IsGenericType
+           && (typedefof<Option<_>> = t.GetGenericTypeDefinition()
+                || t.GetGenericTypeDefinition().IsValueType)) // Nullable<T>
+
+    let typeHasJsonConverterAttribute = memoize (fun (t : Type) -> t.IsDefined(typeof<Serialization.JsonConverterAttribute>, false))
+
+    let propTypeRequiresConstruction (propertyType : Type) =
+        not (isInlinedIntoUnionItem propertyType)
+        && not (typeHasJsonConverterAttribute propertyType)
+
+    /// Prepare arguments for the Case class ctor based on the kind of case and how F# maps that to a Type
+    /// and/or whether we need to let json.net step in to convert argument types
+    let mapTargetCaseArgs (inputJObject : JsonDocument) serializer : PropertyInfo[] -> obj [] = function
+        | [| singleCaseArg |] when propTypeRequiresConstruction singleCaseArg.PropertyType ->
+            [| inputJObject.(singleCaseArg.PropertyType, serializer) |]
+        | multipleFieldsInCustomCaseType ->
+            [| for fi in multipleFieldsInCustomCaseType ->
+                match inputJObject.[fi.Name] with
+                | null when
+                    // Afford converters an opportunity to handle the missing field in the best way I can figure out to signal that
+                    // The specific need being covered (see tests) is to ensure that, even with MissingMemberHandling=Ignore,
+                    // the TypeSafeEnumConverter should reject missing values
+                    // not having this case would go direct to `null` without passing go
+                    typeHasJsonConverterAttribute fi.PropertyType
+                    || serializer.MissingMemberHandling = MissingMemberHandling.Error ->
+                        // NB caller can opt out of erroring by setting NullValueHandling = NullValueHandling.Ignore)
+                        // which renders the following equivalent to the next case
+                        JToken.Parse("null").ToObject(fi.PropertyType, serializer)
+                | null -> null
+                | itemValue -> itemValue.ToObject(fi.PropertyType, serializer) |]
+
+/// Serializes a discriminated union case with a single field that is a
+/// record by flattening the record fields to the same level as the discriminator
+type UnionConverter<'T> private (discriminator : string, ?catchAllCase) =
+    inherit Serialization.JsonConverter<'T>()
+
+    new() = UnionConverter("case")
+    new(discriminator: string, catchAllCase: string) = UnionConverter(discriminator, ?catchAllCase = match catchAllCase with null -> None | x -> Some x)
+
+    override __.CanConvert (t : Type) = Union.tryGetUnion t |> Option.isSome
+
+    override __.Write(writer, value, options) =
+        let union = Union.tryGetUnion (value.GetType())
+        let tag = union.tagReader value
+        let case = union.cases.[tag]
+        let fieldValues = union.fieldReader.[tag] value
+        let fieldInfos = case.GetFields()
+
+        writer.WriteStartObject()
+
+        writer.WritePropertyName(discriminator)
+        writer.WriteValue(case.Name)
+
+        match fieldInfos with
+        | [| fi |] ->
+            match fieldValues.[0] with
+            | null when serializer.NullValueHandling = NullValueHandling.Ignore -> ()
+            | fv ->
+                let token = if fv = null then JToken.Parse "null" else JToken.FromObject(fv, serializer)
+                match token.Type with
+                | JTokenType.Object ->
+                    // flatten the object properties into the same one as the discriminator
+                    for prop in token.Children() do
+                        prop.WriteTo writer
+                | _ ->
+                    writer.WritePropertyName(fi.Name)
+                    token.WriteTo writer
+        | _ ->
+            for fieldInfo, fieldValue in Seq.zip fieldInfos fieldValues do
+                if fieldValue <> null || serializer.NullValueHandling = NullValueHandling.Include then
+                    writer.WritePropertyName(fieldInfo.Name)
+                    serializer.Serialize(writer, fieldValue)
+
+        writer.WriteEndObject()
+
+    override __.Read(reader, t : Type, options) =
+        let token = JToken.ReadFrom reader
+        if token.Type <> JTokenType.Object then raise (FormatException(sprintf "Expected object token, got %O" token.Type))
+        let inputJObject = token :?> JObject
+
+        let union = Union.getUnion t
+        let targetCaseIndex =
+            let inputCaseNameValue = inputJObject.[discriminator] |> string
+            let findCaseNamed x = union.cases |> Array.tryFindIndex (fun case -> case.Name = x)
+            match findCaseNamed inputCaseNameValue, catchAllCase  with
+            | None, None ->
+                sprintf "No case defined for '%s', and no catchAllCase nominated for '%s' on type '%s'"
+                    inputCaseNameValue typeof<UnionConverter>.Name t.FullName |> invalidOp
+            | Some foundIndex, _ -> foundIndex
+            | None, Some catchAllCaseName ->
+                match findCaseNamed catchAllCaseName with
+                | None ->
+                    sprintf "No case defined for '%s', nominated catchAllCase: '%s' not found in type '%s'"
+                        inputCaseNameValue catchAllCaseName t.FullName |> invalidOp
+                | Some foundIndex -> foundIndex
+
+        let targetCaseFields, targetCaseCtor = union.cases.[targetCaseIndex].GetFields(), union.caseConstructor.[targetCaseIndex]
+        targetCaseCtor (Union.mapTargetCaseArgs inputJObject serializer targetCaseFields)

--- a/src/FsCodec.SystemTextJson/UnionConverter.fs
+++ b/src/FsCodec.SystemTextJson/UnionConverter.fs
@@ -114,7 +114,7 @@ type UnionConverter<'T> private (discriminator : string, ?catchAllCase) =
 
         writer.WriteEndObject()
 
-    override __.Read(reader, t : Type, options) =   // TOASK: Change order of methods to satisfy non-uniform instantiation warning
+    override __.Read(reader, t : Type, options) =
         reader.ValidateTokenType(JsonTokenType.StartObject)
         use document = JsonDocument.ParseValue &reader
         let element = document.RootElement

--- a/src/FsCodec.SystemTextJson/UnionConverter.fs
+++ b/src/FsCodec.SystemTextJson/UnionConverter.fs
@@ -1,4 +1,4 @@
-﻿namespace FsCodec.SystemTextJson.Converters
+﻿namespace FsCodec.SystemTextJson
 
 open FsCodec.SystemTextJson
 open FsCodec.SystemTextJson.Core

--- a/src/FsCodec.SystemTextJson/UnionConverter.fs
+++ b/src/FsCodec.SystemTextJson/UnionConverter.fs
@@ -79,7 +79,7 @@ module private Union =
         && not (typeHasJsonConverterAttribute propertyType)
 
     /// Prepare arguments for the Case class ctor based on the kind of case and how F# maps that to a Type
-    /// and/or whether we need to let json.net step in to convert argument types
+    /// and/or whether we need to defer to System.Text.Json
     let mapTargetCaseArgs (element : JsonElement) options (props : PropertyInfo[]) : obj [] =
         match props with
         | [| singleCaseArg |] when propTypeRequiresConstruction singleCaseArg.PropertyType ->

--- a/src/FsCodec.SystemTextJson/UnionConverter.fs
+++ b/src/FsCodec.SystemTextJson/UnionConverter.fs
@@ -5,6 +5,8 @@ open System
 open System.Reflection
 open System.Text.Json
 
+open FsCodec.SystemTextJson.Core
+
 [<NoComparison; NoEquality>]
 type private Union =
     {
@@ -46,24 +48,26 @@ module private Union =
 
     /// Prepare arguments for the Case class ctor based on the kind of case and how F# maps that to a Type
     /// and/or whether we need to let json.net step in to convert argument types
-    let mapTargetCaseArgs (inputJObject : JsonDocument) serializer : PropertyInfo[] -> obj [] = function
+    let mapTargetCaseArgs (element : JsonElement) options : PropertyInfo[] -> obj [] = function
         | [| singleCaseArg |] when propTypeRequiresConstruction singleCaseArg.PropertyType ->
-            [| inputJObject.(singleCaseArg.PropertyType, serializer) |]
+            [| JsonSerializer.DeserializeElement (element, singleCaseArg.PropertyType, options) |]
         | multipleFieldsInCustomCaseType ->
             [| for fi in multipleFieldsInCustomCaseType ->
-                match inputJObject.[fi.Name] with
-                | null when
-                    // Afford converters an opportunity to handle the missing field in the best way I can figure out to signal that
-                    // The specific need being covered (see tests) is to ensure that, even with MissingMemberHandling=Ignore,
-                    // the TypeSafeEnumConverter should reject missing values
-                    // not having this case would go direct to `null` without passing go
-                    typeHasJsonConverterAttribute fi.PropertyType
-                    || serializer.MissingMemberHandling = MissingMemberHandling.Error ->
-                        // NB caller can opt out of erroring by setting NullValueHandling = NullValueHandling.Ignore)
-                        // which renders the following equivalent to the next case
-                        JToken.Parse("null").ToObject(fi.PropertyType, serializer)
-                | null -> null
-                | itemValue -> itemValue.ToObject(fi.PropertyType, serializer) |]
+                match element.GetProperty fi.Name with
+                // TOTHINK: I'm not sure this applies with STJ
+
+                //| null when
+                //    // Afford converters an opportunity to handle the missing field in the best way I can figure out to signal that
+                //    // The specific need being covered (see tests) is to ensure that, even with MissingMemberHandling=Ignore,
+                //    // the TypeSafeEnumConverter should reject missing values
+                //    // not having this case would go direct to `null` without passing go
+                //    typeHasJsonConverterAttribute fi.PropertyType
+                //    || serializer.MissingMemberHandling = MissingMemberHandling.Error ->
+                //        // NB caller can opt out of erroring by setting NullValueHandling = NullValueHandling.Ignore)
+                //        // which renders the following equivalent to the next case
+                //        JToken.Parse("null").ToObject(fi.PropertyType, serializer)
+                | el when el.ValueKind = JsonValueKind.Null -> null
+                | el -> JsonSerializer.DeserializeElement (el, fi.PropertyType, options) |]
 
 /// Serializes a discriminated union case with a single field that is a
 /// record by flattening the record fields to the same level as the discriminator
@@ -76,7 +80,8 @@ type UnionConverter<'T> private (discriminator : string, ?catchAllCase) =
     override __.CanConvert (t : Type) = Union.tryGetUnion t |> Option.isSome
 
     override __.Write(writer, value, options) =
-        let union = Union.tryGetUnion (value.GetType())
+        let value = box value
+        let union = Union.tryGetUnion (value.GetType()) |> Option.get // TOASK: Do we wanna keep the try?
         let tag = union.tagReader value
         let case = union.cases.[tag]
         let fieldValues = union.fieldReader.[tag] value
@@ -85,43 +90,43 @@ type UnionConverter<'T> private (discriminator : string, ?catchAllCase) =
         writer.WriteStartObject()
 
         writer.WritePropertyName(discriminator)
-        writer.WriteValue(case.Name)
+        writer.WriteStringValue(case.Name)
 
         match fieldInfos with
         | [| fi |] ->
             match fieldValues.[0] with
-            | null when serializer.NullValueHandling = NullValueHandling.Ignore -> ()
+            | null when options.IgnoreNullValues -> ()
             | fv ->
-                let token = if fv = null then JToken.Parse "null" else JToken.FromObject(fv, serializer)
-                match token.Type with
-                | JTokenType.Object ->
+                let element = JsonSerializer.SerializeToElement(fv, options)
+                match element.ValueKind with
+                | JsonValueKind.Object ->
                     // flatten the object properties into the same one as the discriminator
-                    for prop in token.Children() do
+                    for prop in element.EnumerateObject() do
                         prop.WriteTo writer
                 | _ ->
                     writer.WritePropertyName(fi.Name)
-                    token.WriteTo writer
+                    element.WriteTo writer
         | _ ->
             for fieldInfo, fieldValue in Seq.zip fieldInfos fieldValues do
-                if fieldValue <> null || serializer.NullValueHandling = NullValueHandling.Include then
+                if fieldValue <> null || not options.IgnoreNullValues then
                     writer.WritePropertyName(fieldInfo.Name)
-                    serializer.Serialize(writer, fieldValue)
+                    JsonSerializer.Serialize(writer, fieldValue, options)
 
         writer.WriteEndObject()
 
-    override __.Read(reader, t : Type, options) =
-        let token = JToken.ReadFrom reader
-        if token.Type <> JTokenType.Object then raise (FormatException(sprintf "Expected object token, got %O" token.Type))
-        let inputJObject = token :?> JObject
+    override __.Read(reader, t : Type, options) =   // TOASK: Change order of methods to satisfy non-uniform instantiation warning
+        reader.ValidateTokenType(JsonTokenType.StartObject)
+        use document = JsonDocument.ParseValue &reader
+        let element = document.RootElement
 
-        let union = Union.getUnion t
+        let union = Union.tryGetUnion t |> Option.get // TOASK: Do we wanna keep the try?
         let targetCaseIndex =
-            let inputCaseNameValue = inputJObject.[discriminator] |> string
+            let inputCaseNameValue = element.GetProperty discriminator |> string
             let findCaseNamed x = union.cases |> Array.tryFindIndex (fun case -> case.Name = x)
             match findCaseNamed inputCaseNameValue, catchAllCase  with
             | None, None ->
                 sprintf "No case defined for '%s', and no catchAllCase nominated for '%s' on type '%s'"
-                    inputCaseNameValue typeof<UnionConverter>.Name t.FullName |> invalidOp
+                    inputCaseNameValue typeof<UnionConverter<_>>.Name t.FullName |> invalidOp
             | Some foundIndex, _ -> foundIndex
             | None, Some catchAllCaseName ->
                 match findCaseNamed catchAllCaseName with
@@ -131,4 +136,4 @@ type UnionConverter<'T> private (discriminator : string, ?catchAllCase) =
                 | Some foundIndex -> foundIndex
 
         let targetCaseFields, targetCaseCtor = union.cases.[targetCaseIndex].GetFields(), union.caseConstructor.[targetCaseIndex]
-        targetCaseCtor (Union.mapTargetCaseArgs inputJObject serializer targetCaseFields)
+        targetCaseCtor (Union.mapTargetCaseArgs element options targetCaseFields) :?> 'T

--- a/tests/FsCodec.SystemTextJson.Tests/FsCodec.SystemTextJson.Tests.fsproj
+++ b/tests/FsCodec.SystemTextJson.Tests/FsCodec.SystemTextJson.Tests.fsproj
@@ -23,11 +23,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="Samples.fs" />
     <Compile Include="PicklerTests.fs" />
     <Compile Include="CodecTests.fs" />
     <Compile Include="SerdesTests.fs" />
     <Compile Include="UmxInteropTests.fs" />
     <Compile Include="TypeSafeEnumConverterTests.fs" />
+    <Compile Include="UnionConverterTests.fs" />
     <None Include="Examples.fsx" />
     <Compile Include="InteropTests.fs" />
   </ItemGroup>

--- a/tests/FsCodec.SystemTextJson.Tests/PicklerTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/PicklerTests.fs
@@ -1,7 +1,6 @@
 module FsCodec.SystemTextJson.Tests.PicklerTests
 
 open FsCodec.SystemTextJson
-open FsCodec.SystemTextJson.Converters
 open Swensen.Unquote
 open System
 open System.Text.Json

--- a/tests/FsCodec.SystemTextJson.Tests/Samples.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/Samples.fs
@@ -1,0 +1,59 @@
+﻿module FsCodec.SystemTextJson.Tests.Samples
+
+open FsCodec.SystemTextJson
+open Newtonsoft.Json
+open System
+open System.Runtime.Serialization
+
+/// Endows any type that inherits this class with standard .NET comparison semantics using a supplied token identifier
+[<AbstractClass>]
+type Comparable<'TComp, 'Token when 'TComp :> Comparable<'TComp, 'Token> and 'Token : comparison>(token : 'Token) =
+    member private __.Token = token // I can haz protected?
+    override x.Equals y = match y with :? Comparable<'TComp, 'Token> as y -> x.Token = y.Token | _ -> false
+    override __.GetHashCode() = hash token
+    interface IComparable with
+        member x.CompareTo y =
+            match y with
+            | :? Comparable<'TComp, 'Token> as y -> compare x.Token y.Token
+            | _ -> invalidArg "y" "invalid comparand"
+
+/// SkuId strongly typed id
+[<Sealed; JsonConverter(typeof<SkuIdJsonConverter>); AutoSerializable(false); StructuredFormatDisplay("{Value}")>]
+// (Internally a string for most efficient copying semantics)
+type SkuId private (id : string) =
+    inherit Comparable<SkuId, string>(id)
+    [<IgnoreDataMember>] // Prevent swashbuckle inferring there's a "value" field
+    member __.Value = id
+    override __.ToString () = id
+    new (guid: Guid) = SkuId (guid.ToString("N"))
+    // NB tests (specifically, empty) lean on having a ctor of this shape
+    new() = SkuId(Guid.NewGuid())
+    // NB for validation [and XSS] purposes we prove it translatable to a Guid
+    static member Parse(input: string) = SkuId (Guid.Parse input)
+/// Represent as a Guid.ToString("N") output externally
+and private SkuIdJsonConverter() =
+    inherit JsonIsomorphism<SkuId, string>()
+    /// Renders as per Guid.ToString("N")
+    override __.Pickle value = value.Value
+    /// Input must be a Guid.Parseable value
+    override __.UnPickle input = SkuId.Parse input
+
+/// CartId strongly typed id
+[<Sealed; JsonConverter(typeof<CartIdJsonConverter>); AutoSerializable(false); StructuredFormatDisplay("{Value}")>]
+// (Internally a string for most efficient copying semantics)
+type CartId private (id : string) =
+    inherit Comparable<CartId, string>(id)
+    [<IgnoreDataMember>] // Prevent swashbuckle inferring there's a "value" field
+    member __.Value = id
+    override __.ToString () = id
+    // NB tests lean on having a ctor of this shape
+    new (guid: Guid) = CartId (guid.ToString("N"))
+    // NB for validation [and XSS] purposes we must prove it translatable to a Guid
+    static member Parse(input: string) = CartId (Guid.Parse input)
+/// Represent as a Guid.ToString("N") output externally
+and private CartIdJsonConverter() =
+    inherit JsonIsomorphism<CartId, string>()
+    /// Renders as per Guid.ToString("N")
+    override __.Pickle value = value.Value
+    /// Input must be a Guid.Parseable value
+    override __.UnPickle input = CartId.Parse input

--- a/tests/FsCodec.SystemTextJson.Tests/Samples.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/Samples.fs
@@ -1,9 +1,9 @@
 ﻿module FsCodec.SystemTextJson.Tests.Samples
 
 open FsCodec.SystemTextJson
-open Newtonsoft.Json
 open System
 open System.Runtime.Serialization
+open System.Text.Json.Serialization
 
 /// Endows any type that inherits this class with standard .NET comparison semantics using a supplied token identifier
 [<AbstractClass>]

--- a/tests/FsCodec.SystemTextJson.Tests/Samples.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/Samples.fs
@@ -31,7 +31,7 @@ type SkuId private (id : string) =
     // NB for validation [and XSS] purposes we prove it translatable to a Guid
     static member Parse(input: string) = SkuId (Guid.Parse input)
 /// Represent as a Guid.ToString("N") output externally
-and private SkuIdJsonConverter() =
+and SkuIdJsonConverter() =
     inherit JsonIsomorphism<SkuId, string>()
     /// Renders as per Guid.ToString("N")
     override __.Pickle value = value.Value
@@ -51,7 +51,7 @@ type CartId private (id : string) =
     // NB for validation [and XSS] purposes we must prove it translatable to a Guid
     static member Parse(input: string) = CartId (Guid.Parse input)
 /// Represent as a Guid.ToString("N") output externally
-and private CartIdJsonConverter() =
+and CartIdJsonConverter() =
     inherit JsonIsomorphism<CartId, string>()
     /// Renders as per Guid.ToString("N")
     override __.Pickle value = value.Value

--- a/tests/FsCodec.SystemTextJson.Tests/SerdesTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/SerdesTests.fs
@@ -24,7 +24,7 @@ module StjCharacterization =
                 | Choice2Of2 m -> m.Contains "Deserialization of reference types without parameterless constructor is not supported. Type 'FsCodec.SystemTextJson.Tests.SerdesTests+Record'" @>
 
     let [<Fact>] ``OOTB STJ options`` () =
-        let ootbOptionsWithRecordConverter = Options.CreateDefault(converters = [|Converters.JsonRecordConverter()|])
+        let ootbOptionsWithRecordConverter = Options.CreateDefault(converters = [|JsonRecordConverter()|])
         let value = { a = 1; b = Some "str" }
         let ser =  Serdes.Serialize(value, ootbOptions)
         test <@ ser = """{"a":1,"b":{"Value":"str"}}""" @>
@@ -40,8 +40,8 @@ module StjCharacterization =
     // - and is not in alignment with the FsCodec.NewtonsoftJson default options
     // see https://github.com/dotnet/runtime/issues/28567#issuecomment-53581752 for lowdown
     let asRequiredForExamples : System.Text.Json.Serialization.JsonConverter [] =
-        [| Converters.JsonOptionConverter()
-           Converters.JsonRecordConverter() |]
+        [| JsonOptionConverter()
+           JsonRecordConverter() |]
     type OverescapedOptions() as this =
         inherit TheoryData<System.Text.Json.JsonSerializerOptions>()
 

--- a/tests/FsCodec.SystemTextJson.Tests/SerdesTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/SerdesTests.fs
@@ -40,8 +40,7 @@ module StjCharacterization =
     // - and is not in alignment with the FsCodec.NewtonsoftJson default options
     // see https://github.com/dotnet/runtime/issues/28567#issuecomment-53581752 for lowdown
     let asRequiredForExamples : System.Text.Json.Serialization.JsonConverter [] =
-        [| JsonOptionConverter()
-           JsonRecordConverter() |]
+        [| JsonOptionConverter(); JsonRecordConverter() |]
     type OverescapedOptions() as this =
         inherit TheoryData<System.Text.Json.JsonSerializerOptions>()
 

--- a/tests/FsCodec.SystemTextJson.Tests/TypeSafeEnumConverterTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/TypeSafeEnumConverterTests.fs
@@ -1,6 +1,7 @@
 module FsCodec.SystemTextJson.Tests.TypeSafeEnumConverterTests
 
 open FsCodec.SystemTextJson
+open FsCodec.SystemTextJson.Converters
 open System
 open System.Collections.Generic
 open System.Text.Json

--- a/tests/FsCodec.SystemTextJson.Tests/TypeSafeEnumConverterTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/TypeSafeEnumConverterTests.fs
@@ -1,7 +1,6 @@
 module FsCodec.SystemTextJson.Tests.TypeSafeEnumConverterTests
 
 open FsCodec.SystemTextJson
-open FsCodec.SystemTextJson.Converters
 open System
 open System.Collections.Generic
 open System.Text.Json

--- a/tests/FsCodec.SystemTextJson.Tests/UnionConverterTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/UnionConverterTests.fs
@@ -62,7 +62,7 @@ type TestDU =
 
 // no camel case, because I want to test "Item" as a record property
 // Centred on ignoreNulls for backcompat; round-tripping test covers the case where they get rendered too
-let defaultOptions = Options.Create(camelCase = false, ignoreNulls = true)
+let defaultOptions = Options.Create(converters = [| UnionConverter<TestDU> () |], camelCase = false, ignoreNulls = true)
 
 
 [<Fact>]

--- a/tests/FsCodec.SystemTextJson.Tests/UnionConverterTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/UnionConverterTests.fs
@@ -143,53 +143,6 @@ let ``deserializes properly`` () =
     test<@ CaseU [| SkuId.Parse "f09f17cb4c9744b4a979afb53be0847f"; SkuId.Parse "c747d53a644d42548b3bbc0988561ce1" |] =
     deserialize """{"case":"CaseU","Item":["f09f17cb4c9744b4a979afb53be0847f","c747d53a644d42548b3bbc0988561ce1"]}"""@>
 
-//module MissingFieldsHandling =
-
-//    let rejectMissingSettings =
-//        [   JsonSerializerSettings(MissingMemberHandling = MissingMemberHandling.Error)
-//            Settings.CreateDefault(errorOnMissing=true)
-//            Settings.Create(errorOnMissing=true)]
-
-//    [<Fact>]
-//    let ``lets converters reject missing values by feeding them a null`` () =
-//        raisesWith <@ JsonConvert.DeserializeObject<TestDU>("""{"case":"CaseY","a":"Fast"}""") @>
-//            (fun e -> <@ "Unexpected token when reading TypeSafeEnum: Null" = e.Message @>)
-//        raises<ArgumentNullException> <@ JsonConvert.DeserializeObject<TestDU>("""{"case":"CaseX"}""") @>
-
-//    [<Fact>]
-//    let ``types with converters that would reject missing values can be guarded by wrapping in an option`` () =
-//        test <@ CaseZ (Fast,None) = JsonConvert.DeserializeObject<TestDU>("""{"case":"CaseZ","a":"Fast"}""") @>
-
-//    [<Fact>]
-//    let ``rejects missing fields bound to non-optional value types when requested`` () =
-//        for s in rejectMissingSettings do
-//            let deserializeWithMissingMembersAsError json = JsonConvert.DeserializeObject<TestDU>(json, s)
-//            raisesWith <@ deserializeWithMissingMembersAsError """{"case":"CaseE","Item3":"hi","Item4":0}"""  @>
-//                (fun (e : JsonSerializationException) ->
-//                    <@  e.Message.StartsWith "Error converting value {null} to type 'System.Int32'. Path ''"
-//                        && e.InnerException.GetType() = typeof<InvalidCastException>
-//                        && e.InnerException.Message.Contains "Null object cannot be converted to a value type." @>)
-
-//    type TestRecordWithArray = { sku : string; [<JsonRequired>]skus: string[] }
-
-//    [<Fact>]
-//    let ``currently can't guard against null Arrays, but that's not a default so we live with it`` () =
-//        raisesWith<JsonSerializationException> <@ JsonConvert.DeserializeObject<TestRecordWithArray>("""{"sku": null }""") @>
-//            (fun e -> <@ e.Message.StartsWith "Required property 'skus' not found in JSON. Path ''" @>)
-//        let missingTheArray = sprintf """{"case":"CaseX","a":"%O"}""" Guid.Empty
-//        test <@ CaseX (CartId Guid.Empty,null) = JsonConvert.DeserializeObject<TestDU>(missingTheArray) @>
-
-//    [<Fact>]
-//    let ``handles missing fields bound to Nullable or optional types`` () =
-//        let deserialize json = JsonConvert.DeserializeObject<TestDU>(json, settings)
-//        test <@ CaseJ (Nullable<int>()) = deserialize """{"case":"CaseJ"}""" @>
-//        test <@ CaseK (1, (Nullable<int>())) = deserialize """{"case":"CaseK","a":1}""" @>
-//        test <@ CaseL ((Nullable<int>()), (Nullable<int>())) = deserialize """{"case":"CaseL"}""" @>
-
-//        test <@ CaseM None = deserialize """{"case":"CaseM"}""" @>
-//        test <@ CaseN (1, None) = deserialize """{"case":"CaseN","a":1}""" @>
-//        test <@ CaseO (None, None) = deserialize """{"case":"CaseO"}""" @>
-
 let (|Q|) (s: string) = JsonSerializer.Serialize(s, defaultOptions)
 
 // Renderings when NullValueHandling=Include, which is the default for Json.net, and used by the recommended Settings.CreateCorrect profile

--- a/tests/FsCodec.SystemTextJson.Tests/UnionConverterTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/UnionConverterTests.fs
@@ -395,3 +395,49 @@ module ``Custom discriminator`` =
         let a = JsonSerializer.Deserialize<DuWithConverterAndOptionsAttribute>(aJson)
 
         test <@ DuWithConverterAndOptionsAttribute.Case1 = a @>
+
+module ``Struct discriminated unions`` =
+    [<Struct>]
+    [<JsonConverter(typeof<UnionConverter>)>]
+    type TestStructDu =
+    | CaseA of a: TestRecordPayload
+    | CaseB
+    | CaseC of string
+    | CaseD of d: string
+    | CaseE of e: string * int
+    | CaseF of f: string * fb: int
+    | CaseG of g: TrickyRecordPayload
+    | CaseH of h: TestRecordPayload
+    | CaseI of i: TestRecordPayload * ib: string
+
+    let defaultOptions = Options.Create(camelCase = false, ignoreNulls = true)
+    let inline serialize x = JsonSerializer.Serialize(x, defaultOptions)
+
+    [<Fact>]
+    let ``produces expected output`` () =
+        let a = CaseA {test = "hi"}
+        test <@ """{"case":"CaseA","test":"hi"}""" = serialize a @>
+    
+        let b = CaseB
+        test <@ """{"case":"CaseB"}""" = serialize b @>
+    
+        let c = CaseC "hi"
+        test <@ """{"case":"CaseC","Item":"hi"}""" = serialize c @>
+    
+        let d = CaseD "hi"
+        test <@ """{"case":"CaseD","d":"hi"}""" = serialize d @>
+    
+        let e = CaseE ("hi", 0)
+        test <@ """{"case":"CaseE","e":"hi","Item2":0}""" = serialize e @>
+    
+        let f = CaseF ("hi", 0)
+        test <@ """{"case":"CaseF","f":"hi","fb":0}""" = serialize f @>
+    
+        let g = CaseG {Item = "hi"}
+        test <@ """{"case":"CaseG","Item":"hi"}""" = serialize g @>
+
+        let h = CaseH {test = "hi"}
+        test <@ """{"case":"CaseH","test":"hi"}""" = serialize h @>
+    
+        let i = CaseI ({test = "hi"}, "bye")
+        test <@ """{"case":"CaseI","i":{"test":"hi"},"ib":"bye"}""" = serialize i @>

--- a/tests/FsCodec.SystemTextJson.Tests/UnionConverterTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/UnionConverterTests.fs
@@ -153,7 +153,7 @@ let ``deserializes properly`` () =
 
 let (|Q|) (s: string) = JsonSerializer.Serialize(s, defaultOptions)
 
-// Renderings when NullValueHandling=Include, which is the default for Json.net, and used by the recommended Settings.CreateCorrect profile
+// Renderings when NullValueHandling=Include, which is used by the recommended Settings.Create profile
 let render ignoreNulls = function
     | CaseA { test = null } when ignoreNulls -> """{"case":"CaseA"}"""
     | CaseA { test = Q x} -> sprintf """{"case":"CaseA","test":%s}""" x

--- a/tests/FsCodec.SystemTextJson.Tests/UnionConverterTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/UnionConverterTests.fs
@@ -294,7 +294,7 @@ module ``Unmatched case handling`` =
 
     [<Fact>]
     let ``UnionConverter supports a nominated catchall via options`` () =
-        let options = Options.Create(UnionConverter ("case", "Catchall"))
+        let options = Options.Create(UnionConverter<DuWithCatchAllWithoutAttributes> ("case", "Catchall"))
         let aJson = """{"case":"CaseUnknown"}"""
         let a = JsonSerializer.Deserialize<DuWithCatchAllWithoutAttributes>(aJson, options)
 
@@ -302,7 +302,7 @@ module ``Unmatched case handling`` =
 
     [<Fact>]
     let ``UnionConverter supports a nominated catchall with attributes overriding options`` () =
-        let options = Options.Create(UnionConverter ({ discriminator = "case"; catchAllCase = None }))
+        let options = Options.Create(UnionConverter<DuWithCatchAllWithAttributes> ({ discriminator = "case"; catchAllCase = None }))
         let aJson = """{"case":"CaseUnknown"}"""
         let a = JsonSerializer.Deserialize<DuWithCatchAllWithAttributes>(aJson, options)
 
@@ -313,7 +313,7 @@ module ``Unmatched case handling`` =
 
     [<Fact>]
     let ``UnionConverter explains if nominated catchAll not found`` () =
-        let options = Options.Create(UnionConverter ("case", "CatchAllThatCantBeFound"))
+        let options = Options.Create(UnionConverter<DuWithMissingCatchAll> ("case", "CatchAllThatCantBeFound"))
         let aJson = """{"case":"CaseUnknown"}"""
         let act () = JsonSerializer.Deserialize<DuWithMissingCatchAll>(aJson, options)
 
@@ -353,7 +353,7 @@ module ``Custom discriminator`` =
     type DuWithOptionsAttribute =
     | Case1
 
-    [<JsonConverter(typeof<UnionConverter<_>>); JsonUnionConverterOptions("kind")>]
+    [<JsonConverter(typeof<UnionConverter<DuWithConverterAndOptionsAttribute>>); JsonUnionConverterOptions("kind")>]
     type DuWithConverterAndOptionsAttribute =
     | Case1
 

--- a/tests/FsCodec.SystemTextJson.Tests/UnionConverterTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/UnionConverterTests.fs
@@ -1,0 +1,361 @@
+﻿module FsCodec.SystemTextJson.Tests.UnionConverterTests
+
+open FsCheck
+open FsCodec.SystemTextJson
+open Swensen.Unquote.Assertions
+open System
+open System.IO
+open System.Text.Json
+open System.Text.Json.Serialization
+open global.Xunit
+
+open Samples
+
+// TODO support [<Struct>]
+type TestRecordPayload =
+    {
+        test: string
+    }
+
+// TODO support [<Struct>]
+type TrickyRecordPayload =
+    {
+        Item: string
+    }
+
+[<JsonConverter(typeof<TypeSafeEnumConverter<Mode>>)>]
+type Mode =
+    | Fast
+    | Slow
+
+[<NoComparison>] // NB this is not a general restriction; it's forced by use of Nullable<T> in some of the cases in this specific one
+[<JsonConverter(typeof<UnionConverter<TestDU>>)>]
+type TestDU =
+    | CaseA of TestRecordPayload
+    | CaseB
+    | CaseC of string
+    | CaseD of a: string
+    | CaseE of string * int
+    | CaseF of a: string * b: int
+    | CaseG of TrickyRecordPayload
+    | CaseH of a: TestRecordPayload
+    | CaseI of a: TestRecordPayload * b: string
+    | CaseJ of a: Nullable<int>
+    | CaseK of a: int * b: Nullable<int>
+    | CaseL of a: Nullable<int> * b: Nullable<int>
+    | CaseM of a: int option
+    | CaseN of a: int * b: int option
+    | CaseO of a: int option * b: int option
+    | CaseP of CartId
+    | CaseQ of SkuId
+    | CaseR of a: CartId
+    | CaseS of a: SkuId
+    | CaseT of a: SkuId option * b: CartId
+    | CaseU of SkuId[]
+    | CaseV of skus: SkuId[]
+    | CaseW of CartId * SkuId[]
+    | CaseX of a: CartId * skus: SkuId[]
+    | CaseY of a: Mode * b: Mode
+    | CaseZ of a: Mode * b: Mode option
+
+#nowarn "1182" // From hereon in, we may have some 'unused' privates (the tests)
+
+// no camel case, because I want to test "Item" as a record property
+// Centred on ignoreNulls for backcompat; round-tripping test covers the case where they get rendered too
+let defaultOptions = Options.Create(camelCase = false, ignoreNulls = true)
+
+
+[<Fact>]
+let ``produces expected output`` () =
+    let serialize (x : obj) = JsonSerializer.Serialize(x, defaultOptions)
+    let a = CaseA {test = "hi"}
+    test <@ """{"case":"CaseA","test":"hi"}""" = serialize a @>
+
+    let b = CaseB
+    test <@ """{"case":"CaseB"}""" = serialize b @>
+
+    let c = CaseC "hi"
+    test <@ """{"case":"CaseC","Item":"hi"}""" = serialize c @>
+
+    let d = CaseD "hi"
+    test <@ """{"case":"CaseD","a":"hi"}""" = serialize d @>
+
+    let e = CaseE ("hi", 0)
+    test <@ """{"case":"CaseE","Item1":"hi","Item2":0}""" = serialize e @>
+
+    let f = CaseF ("hi", 0)
+    test <@ """{"case":"CaseF","a":"hi","b":0}""" = serialize f @>
+
+    let g = CaseG {Item = "hi"}
+    test <@ """{"case":"CaseG","Item":"hi"}""" = serialize g @>
+
+    // this may not be expected, but I don't intend changing it
+    let h = CaseH {test = "hi"}
+    test <@ """{"case":"CaseH","test":"hi"}""" = serialize h @>
+
+    let i = CaseI ({test = "hi"}, "bye")
+    test <@ """{"case":"CaseI","a":{"test":"hi"},"b":"bye"}""" = serialize i @>
+
+    let p = CaseP (CartId.Parse "0000000000000000948d503fcfc20f17")
+    test <@ """{"case":"CaseP","Item":"0000000000000000948d503fcfc20f17"}""" = serialize p @>
+
+    let u = CaseU [| SkuId.Parse "f09f17cb4c9744b4a979afb53be0847f"; SkuId.Parse "c747d53a644d42548b3bbc0988561ce1" |]
+    test<@ """{"case":"CaseU","Item":["f09f17cb4c9744b4a979afb53be0847f","c747d53a644d42548b3bbc0988561ce1"]}""" = serialize u @>
+
+[<Fact>]
+let ``deserializes properly`` () =
+    let deserialize (json : string) = JsonSerializer.Deserialize<TestDU>(json, defaultOptions)
+    test <@ CaseA {test = null} = deserialize """{"case":"CaseA"}""" @>
+    test <@ CaseA {test = "hi"} = deserialize """{"case":"CaseA","test":"hi"}""" @>
+    test <@ CaseA {test = "hi"} = deserialize """{"case":"CaseA","test":"hi","extraField":"hello"}""" @>
+
+    test <@ CaseB = deserialize """{"case":"CaseB"}""" @>
+
+    test <@ CaseC "hi" = deserialize """{"case":"CaseC","Item":"hi"}""" @>
+
+    test <@ CaseD "hi" = deserialize """{"case":"CaseD","a":"hi"}""" @>
+
+    test <@ CaseE ("hi", 0) = deserialize """{"case":"CaseE","Item1":"hi","Item2":0}""" @>
+    // NB this only passes by virtue of MissingMemberHandling=Ignore and NullValueHandling=Ignore in default settings
+    test <@ CaseE (null, 0) = deserialize """{"case":"CaseE","Item3":"hi","Item4":0}""" @>
+
+    test <@ CaseF ("hi", 0) = deserialize """{"case":"CaseF","a":"hi","b":0}""" @>
+
+    test <@ CaseG {Item = "hi"} = deserialize """{"case":"CaseG","Item":"hi"}""" @>
+
+    test <@ CaseH {test = "hi"} = deserialize """{"case":"CaseH","test":"hi"}""" @>
+
+    test <@ CaseI ({test = "hi"}, "bye") = deserialize """{"case":"CaseI","a":{"test":"hi"},"b":"bye"}""" @>
+
+    test <@ CaseJ (Nullable 1) = deserialize """{"case":"CaseJ","a":1}""" @>
+    test <@ CaseK (1, Nullable 2) = deserialize """{"case":"CaseK", "a":1, "b":2 }""" @>
+    test <@ CaseL (Nullable 1, Nullable 2) = deserialize """{"case":"CaseL", "a": 1, "b": 2 }""" @>
+
+    // TOINVESTIGATE: It looks like Newtonsoft Settings.Create() behaviour is to always add
+    // an OptionConverter? This might not be needed anymore?
+    //let requiredSettingsToHandleOptionalFields = Settings.Create()
+    let deserializeCustom s = deserialize s // JsonConvert.DeserializeObject<TestDU>(s, requiredSettingsToHandleOptionalFields)
+    test <@ CaseM (Some 1) = deserializeCustom """{"case":"CaseM","a":1}""" @>
+    test <@ CaseN (1, Some 2) = deserializeCustom """{"case":"CaseN", "a":1, "b":2 }""" @>
+    test <@ CaseO (Some 1, Some 2) = deserializeCustom """{"case":"CaseO", "a": 1, "b": 2 }""" @>
+
+    test <@ CaseP (CartId.Parse "0000000000000000948d503fcfc20f17") = deserialize """{"case":"CaseP","Item":"0000000000000000948d503fcfc20f17"}""" @>
+
+    test<@ CaseU [| SkuId.Parse "f09f17cb4c9744b4a979afb53be0847f"; SkuId.Parse "c747d53a644d42548b3bbc0988561ce1" |] =
+    deserialize """{"case":"CaseU","Item":["f09f17cb4c9744b4a979afb53be0847f","c747d53a644d42548b3bbc0988561ce1"]}"""@>
+
+//module MissingFieldsHandling =
+
+//    let rejectMissingSettings =
+//        [   JsonSerializerSettings(MissingMemberHandling = MissingMemberHandling.Error)
+//            Settings.CreateDefault(errorOnMissing=true)
+//            Settings.Create(errorOnMissing=true)]
+
+//    [<Fact>]
+//    let ``lets converters reject missing values by feeding them a null`` () =
+//        raisesWith <@ JsonConvert.DeserializeObject<TestDU>("""{"case":"CaseY","a":"Fast"}""") @>
+//            (fun e -> <@ "Unexpected token when reading TypeSafeEnum: Null" = e.Message @>)
+//        raises<ArgumentNullException> <@ JsonConvert.DeserializeObject<TestDU>("""{"case":"CaseX"}""") @>
+
+//    [<Fact>]
+//    let ``types with converters that would reject missing values can be guarded by wrapping in an option`` () =
+//        test <@ CaseZ (Fast,None) = JsonConvert.DeserializeObject<TestDU>("""{"case":"CaseZ","a":"Fast"}""") @>
+
+//    [<Fact>]
+//    let ``rejects missing fields bound to non-optional value types when requested`` () =
+//        for s in rejectMissingSettings do
+//            let deserializeWithMissingMembersAsError json = JsonConvert.DeserializeObject<TestDU>(json, s)
+//            raisesWith <@ deserializeWithMissingMembersAsError """{"case":"CaseE","Item3":"hi","Item4":0}"""  @>
+//                (fun (e : JsonSerializationException) ->
+//                    <@  e.Message.StartsWith "Error converting value {null} to type 'System.Int32'. Path ''"
+//                        && e.InnerException.GetType() = typeof<InvalidCastException>
+//                        && e.InnerException.Message.Contains "Null object cannot be converted to a value type." @>)
+
+//    type TestRecordWithArray = { sku : string; [<JsonRequired>]skus: string[] }
+
+//    [<Fact>]
+//    let ``currently can't guard against null Arrays, but that's not a default so we live with it`` () =
+//        raisesWith<JsonSerializationException> <@ JsonConvert.DeserializeObject<TestRecordWithArray>("""{"sku": null }""") @>
+//            (fun e -> <@ e.Message.StartsWith "Required property 'skus' not found in JSON. Path ''" @>)
+//        let missingTheArray = sprintf """{"case":"CaseX","a":"%O"}""" Guid.Empty
+//        test <@ CaseX (CartId Guid.Empty,null) = JsonConvert.DeserializeObject<TestDU>(missingTheArray) @>
+
+//    [<Fact>]
+//    let ``handles missing fields bound to Nullable or optional types`` () =
+//        let deserialize json = JsonConvert.DeserializeObject<TestDU>(json, settings)
+//        test <@ CaseJ (Nullable<int>()) = deserialize """{"case":"CaseJ"}""" @>
+//        test <@ CaseK (1, (Nullable<int>())) = deserialize """{"case":"CaseK","a":1}""" @>
+//        test <@ CaseL ((Nullable<int>()), (Nullable<int>())) = deserialize """{"case":"CaseL"}""" @>
+
+//        test <@ CaseM None = deserialize """{"case":"CaseM"}""" @>
+//        test <@ CaseN (1, None) = deserialize """{"case":"CaseN","a":1}""" @>
+//        test <@ CaseO (None, None) = deserialize """{"case":"CaseO"}""" @>
+
+let (|Q|) (s: string) = Newtonsoft.Json.JsonConvert.SerializeObject s
+
+// Renderings when NullValueHandling=Include, which is the default for Json.net, and used by the recommended Settings.CreateCorrect profile
+//let render ignoreNulls = function
+//    | CaseA { test = null } when ignoreNulls -> """{"case":"CaseA"}"""
+//    | CaseA { test = Q x} -> sprintf """{"case":"CaseA","test":%s}""" x
+//    | CaseB -> """{"case":"CaseB"}"""
+//    | CaseC null when ignoreNulls -> """{"case":"CaseC"}"""
+//    | CaseC (Q s) -> sprintf """{"case":"CaseC","Item":%s}""" s
+//    | CaseD null when ignoreNulls -> """{"case":"CaseD"}"""
+//    | CaseD (Q s) -> sprintf """{"case":"CaseD","a":%s}""" s
+//    | CaseE (null,y) when ignoreNulls -> sprintf """{"case":"CaseE","Item2":%d}""" y
+//    | CaseE (null,y) -> sprintf """{"case":"CaseE","Item1":null,"Item2":%d}""" y
+//    | CaseE (Q x,y) -> sprintf """{"case":"CaseE","Item1":%s,"Item2":%d}""" x y
+//    | CaseF (null,y) when ignoreNulls -> sprintf """{"case":"CaseF","b":%d}""" y
+//    | CaseF (null,y) -> sprintf """{"case":"CaseF","a":null,"b":%d}""" y
+//    | CaseF (Q x,y) -> sprintf """{"case":"CaseF","a":%s,"b":%d}""" x y
+//    | CaseG {Item = null} when ignoreNulls  -> """{"case":"CaseG"}"""
+//    | CaseG {Item = Q s} -> sprintf """{"case":"CaseG","Item":%s}""" s
+//    | CaseH {test = null} when ignoreNulls -> """{"case":"CaseH"}"""
+//    | CaseH {test = Q s} -> sprintf """{"case":"CaseH","test":%s}""" s
+//    | CaseI ({test = null}, null) when ignoreNulls -> """{"case":"CaseI","a":{}}"""
+//    | CaseI ({test = null}, null) -> """{"case":"CaseI","a":{"test":null},"b":null}"""
+//    | CaseI ({test = null}, Q s) when ignoreNulls -> sprintf """{"case":"CaseI","a":{},"b":%s}""" s
+//    | CaseI ({test = null}, Q s) -> sprintf """{"case":"CaseI","a":{"test":null},"b":%s}""" s
+//    | CaseI ({test = Q s}, null) when ignoreNulls -> sprintf """{"case":"CaseI","a":{"test":%s}}""" s
+//    | CaseI ({test = Q s}, null) -> sprintf """{"case":"CaseI","a":{"test":%s},"b":null}""" s
+//    | CaseI ({test = Q s}, Q b) -> sprintf """{"case":"CaseI","a":{"test":%s},"b":%s}""" s b
+
+//    | CaseJ x when not x.HasValue && ignoreNulls -> """{"case":"CaseJ"}"""
+//    | CaseJ x when not x.HasValue -> """{"case":"CaseJ","a":null}"""
+//    | CaseJ x -> sprintf """{"case":"CaseJ","a":%d}""" x.Value
+//    | CaseK (a,x) when not x.HasValue && ignoreNulls -> sprintf """{"case":"CaseK","a":%d}""" a
+//    | CaseK (a,x) when not x.HasValue -> sprintf """{"case":"CaseK","a":%d,"b":null}""" a
+//    | CaseK (a,x) -> sprintf """{"case":"CaseK","a":%d,"b":%d}""" a x.Value
+//    | CaseL (a,b) when not a.HasValue && not b.HasValue && ignoreNulls -> """{"case":"CaseL"}"""
+//    | CaseL (a,b) when not a.HasValue && not b.HasValue -> """{"case":"CaseL","a":null,"b":null}"""
+//    | CaseL (a,b) when not a.HasValue && ignoreNulls -> sprintf """{"case":"CaseL","b":%d}""" b.Value
+//    | CaseL (a,b) when not a.HasValue -> sprintf """{"case":"CaseL","a":null,"b":%d}""" b.Value
+//    | CaseL (a,b) when not b.HasValue && ignoreNulls -> sprintf """{"case":"CaseL","a":%d}""" a.Value
+//    | CaseL (a,b) when not b.HasValue -> sprintf """{"case":"CaseL","a":%d,"b":null}""" a.Value
+//    | CaseL (a,b) -> sprintf """{"case":"CaseL","a":%d,"b":%d}""" a.Value b.Value
+
+//    | CaseM None when ignoreNulls -> """{"case":"CaseM"}"""
+//    | CaseM None -> """{"case":"CaseM","a":null}"""
+//    | CaseM (Some x) -> sprintf """{"case":"CaseM","a":%d}""" x
+//    | CaseN (a,None) when ignoreNulls -> sprintf """{"case":"CaseN","a":%d}""" a
+//    | CaseN (a,None) -> sprintf """{"case":"CaseN","a":%d,"b":null}""" a
+//    | CaseN (a,x) -> sprintf """{"case":"CaseN","a":%d,"b":%d}""" a x.Value
+//    | CaseO (None,None) when ignoreNulls -> """{"case":"CaseO"}"""
+//    | CaseO (None,None) -> """{"case":"CaseO","a":null,"b":null}"""
+//    | CaseO (None,b) when ignoreNulls -> sprintf """{"case":"CaseO","b":%d}""" b.Value
+//    | CaseO (None,b) -> sprintf """{"case":"CaseO","a":null,"b":%d}""" b.Value
+//    | CaseO (a,None) when ignoreNulls -> sprintf """{"case":"CaseO","a":%d}""" a.Value
+//    | CaseO (a,None) -> sprintf """{"case":"CaseO","a":%d,"b":null}""" a.Value
+//    | CaseO (Some a,Some b) -> sprintf """{"case":"CaseO","a":%d,"b":%d}""" a b
+//    | CaseP id -> sprintf """{"case":"CaseP","Item":"%s"}""" id.Value
+//    | CaseQ id -> sprintf """{"case":"CaseQ","Item":"%s"}""" id.Value
+//    | CaseR id -> sprintf """{"case":"CaseR","a":"%s"}""" id.Value
+//    | CaseS id -> sprintf """{"case":"CaseS","a":"%s"}""" id.Value
+//    | CaseT (None, x) when ignoreNulls -> sprintf """{"case":"CaseT","b":"%s"}""" x.Value
+//    | CaseT (None, x) -> sprintf """{"case":"CaseT","a":null,"b":"%s"}""" x.Value
+//    | CaseT (Some x, y) -> sprintf """{"case":"CaseT","a":"%s","b":"%s"}""" x.Value y.Value
+//    | CaseU skus -> sprintf """{"case":"CaseU","Item":[%s]}""" (skus |> Seq.map (fun s -> sprintf "\"%s\"" s.Value) |> String.concat ",")
+//    | CaseV skus -> sprintf """{"case":"CaseV","skus":[%s]}""" (skus |> Seq.map (fun s -> sprintf "\"%s\"" s.Value) |> String.concat ",")
+//    | CaseW (id, skus) -> sprintf """{"case":"CaseW","Item1":"%s","Item2":[%s]}""" id.Value (skus |> Seq.map (fun s -> sprintf "\"%s\"" s.Value) |> String.concat ",")
+//    | CaseX (id, skus) -> sprintf """{"case":"CaseX","a":"%s","skus":[%s]}""" id.Value (skus |> Seq.map (fun s -> sprintf "\"%s\"" s.Value) |> String.concat ",")
+//    | CaseY (a, b) -> sprintf """{"case":"CaseY","a":"%s","b":"%s"}""" (string a) (string b)
+//    | CaseZ (a, None) when ignoreNulls -> sprintf """{"case":"CaseZ","a":"%s"}""" (string a)
+//    | CaseZ (a, None) -> sprintf """{"case":"CaseZ","a":"%s","b":null}""" (string a)
+//    | CaseZ (a, Some b) -> sprintf """{"case":"CaseZ","a":"%s","b":"%s"}""" (string a) (string b)
+//    | CaseZ (a, Some b) -> sprintf """{"case":"CaseZ","a":"%s","b":"%s"}""" (string a) (string b)
+
+//type FsCheckGenerators =
+//    static member CartId = Arb.generate |> Gen.map CartId |> Arb.fromGen
+//    static member SkuId = Arb.generate |> Gen.map SkuId |> Arb.fromGen
+
+//type DomainPropertyAttribute() =
+//    inherit FsCheck.Xunit.PropertyAttribute(QuietOnSuccess = true, Arbitrary=[| typeof<FsCheckGenerators> |])
+
+//let roundtripProperty ignoreNulls (profile : JsonSerializerSettings) value =
+//    let serialized = JsonConvert.SerializeObject(value, profile)
+//    render ignoreNulls value =! serialized
+//    let deserialized = JsonConvert.DeserializeObject<_>(serialized, profile)
+//    deserialized =! value
+
+//let includeNullsProfile = Settings.CreateDefault(OptionConverter())
+//[<DomainPropertyAttribute(MaxTest=1000)>]
+//let ``UnionConverter ignoreNulls Profile roundtrip property test`` (x: TestDU) =
+//    let ignoreNulls, profile = false, includeNullsProfile
+//    profile.NullValueHandling =! NullValueHandling.Include
+//    roundtripProperty ignoreNulls profile x
+
+//let defaultProfile = Settings.Create()
+//[<DomainPropertyAttribute(MaxTest=1000)>]
+//let ``UnionConverter opinionated Profile roundtrip property test`` (x: TestDU) =
+//    let ignoreNulls, profile = false, defaultProfile
+//    profile.NullValueHandling =! NullValueHandling.Include
+//    roundtripProperty ignoreNulls profile x
+
+//[<Fact>]
+//let ``Implementation ensures no internal errors escape (which would render a WebApi ModelState.Invalid)`` () =
+//    let s = JsonSerializer.CreateDefault()
+//    let mutable gotError = false
+//    s.Error.Add(fun _ -> gotError <- true)
+
+//    let dJson = """{"case":"CaseD","a":"hi"}"""
+//    use dReader = new StringReader(dJson)
+//    use dJsonReader = new JsonTextReader(dReader)
+//    let d = s.Deserialize<TestDU>(dJsonReader)
+
+//    test <@ (CaseD "hi") = d @>
+//    test <@ false = gotError @>
+
+//module ``Unmatched case handling`` =
+
+//    [<Fact>]
+//    let ``UnionConverter by default throws on unknown cases`` () =
+//        let aJson = """{"case":"CaseUnknown"}"""
+//        let act () = JsonConvert.DeserializeObject<TestDU>(aJson, settings)
+
+//        fun (e : System.InvalidOperationException) -> <@ -1 <> e.Message.IndexOf "No case defined for 'CaseUnknown', and no catchAllCase nominated" @>
+//        |> raisesWith <@ act() @>
+
+//    [<JsonConverter(typeof<UnionConverter>, "case", "Catchall")>]
+//    type DuWithCatchAll =
+//    | Known
+//    | Catchall
+
+//    [<Fact>]
+//    let ``UnionConverter supports a nominated catchall`` () =
+//        let aJson = """{"case":"CaseUnknown"}"""
+//        let a = JsonConvert.DeserializeObject<DuWithCatchAll>(aJson, settings)
+
+//        test <@ Catchall = a @>
+
+//    [<JsonConverter(typeof<UnionConverter>, "case", "CatchAllThatCantBeFound")>]
+//    type DuWithMissingCatchAll =
+//    | Known
+
+//    [<Fact>]
+//    let ``UnionConverter explains if nominated catchAll not found`` () =
+//        let aJson = """{"case":"CaseUnknown"}"""
+//        let act () = JsonConvert.DeserializeObject<DuWithMissingCatchAll>(aJson, settings)
+
+//        fun (e : System.InvalidOperationException) -> <@ -1 <> e.Message.IndexOf "nominated catchAllCase: 'CatchAllThatCantBeFound' not found" @>
+//        |> raisesWith <@ act() @>
+
+//    [<NoComparison>] // Forced by usage of JObject
+//    [<JsonConverter(typeof<UnionConverter>, "case", "Catchall")>]
+//    type DuWithCatchAllWithFields =
+//    | Known
+//    | Catchall of Newtonsoft.Json.Linq.JObject
+
+//    [<Fact>]
+//    let ``UnionConverter can feed unknown values into a JObject for logging or post processing`` () =
+//        let deserialize json = JsonConvert.DeserializeObject<DuWithCatchAllWithFields>(json, settings)
+//        let jo =
+//            trap <@ match deserialize """{"case":"CaseUnknown","a":"s","b":1,"c":true}""" with
+//                    | Catchall jo -> jo
+//                    | x -> failwithf "unexpected %A" x @>
+
+//        test <@ string jo.["a"]="s"
+//                && jo.["b"].Type=Newtonsoft.Json.Linq.JTokenType.Integer
+//                && jo.["c"].Type=Newtonsoft.Json.Linq.JTokenType.Boolean
+//                && string jo.["case"]="CaseUnknown" @>
+//        let expected  = "{\r\n  \"case\": \"CaseUnknown\",\r\n  \"a\": \"s\",\r\n  \"b\": 1,\r\n  \"c\": true\r\n}".Replace("\r\n",Environment.NewLine)
+//        test <@ expected = string jo @>

--- a/tests/FsCodec.SystemTextJson.Tests/UnionConverterTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/UnionConverterTests.fs
@@ -2,6 +2,7 @@
 
 open FsCheck
 open FsCodec.SystemTextJson
+open FsCodec.SystemTextJson.Converters
 open Swensen.Unquote.Assertions
 open System
 open System.IO

--- a/tests/FsCodec.SystemTextJson.Tests/UnionConverterTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/UnionConverterTests.fs
@@ -63,12 +63,11 @@ type TestDU =
 
 // no camel case, because I want to test "Item" as a record property
 // Centred on ignoreNulls for backcompat; round-tripping test covers the case where they get rendered too
-let defaultOptions = Options.Create(converters = [| UnionConverter<TestDU> (); SkuIdJsonConverter (); CartIdJsonConverter () |], camelCase = false, ignoreNulls = true)
-
+let defaultOptions = Options.Create(camelCase = false, ignoreNulls = true)
+let inline serialize x = JsonSerializer.Serialize(x, defaultOptions)
 
 [<Fact>]
 let ``produces expected output`` () =
-    let serialize (x : obj) = JsonSerializer.Serialize(x, defaultOptions)
     let a = CaseA {test = "hi"}
     test <@ """{"case":"CaseA","test":"hi"}""" = serialize a @>
 

--- a/tests/FsCodec.SystemTextJson.Tests/UnionConverterTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/UnionConverterTests.fs
@@ -63,7 +63,7 @@ type TestDU =
 
 // no camel case, because I want to test "Item" as a record property
 // Centred on ignoreNulls for backcompat; round-tripping test covers the case where they get rendered too
-let defaultOptions = Options.Create(converters = [| UnionConverter<TestDU> () |], camelCase = false, ignoreNulls = true)
+let defaultOptions = Options.Create(converters = [| UnionConverter<TestDU> (); SkuIdJsonConverter (); CartIdJsonConverter () |], camelCase = false, ignoreNulls = true)
 
 
 [<Fact>]

--- a/tests/FsCodec.SystemTextJson.Tests/UnionConverterTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/UnionConverterTests.fs
@@ -116,7 +116,7 @@ let ``deserializes properly`` () =
     test <@ CaseD "hi" = deserialize """{"case":"CaseD","a":"hi"}""" @>
 
     test <@ CaseE ("hi", 0) = deserialize """{"case":"CaseE","Item1":"hi","Item2":0}""" @>
-    // NB this only passes by virtue of MissingMemberHandling=Ignore and NullValueHandling=Ignore in default settings
+
     test <@ CaseE (null, 0) = deserialize """{"case":"CaseE","Item3":"hi","Item4":0}""" @>
 
     test <@ CaseF ("hi", 0) = deserialize """{"case":"CaseF","a":"hi","b":0}""" @>

--- a/tests/FsCodec.SystemTextJson.Tests/UnionConverterTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/UnionConverterTests.fs
@@ -191,105 +191,105 @@ let ``deserializes properly`` () =
 //        test <@ CaseN (1, None) = deserialize """{"case":"CaseN","a":1}""" @>
 //        test <@ CaseO (None, None) = deserialize """{"case":"CaseO"}""" @>
 
-let (|Q|) (s: string) = Newtonsoft.Json.JsonConvert.SerializeObject s
+let (|Q|) (s: string) = JsonSerializer.Serialize(s, defaultOptions)
 
 // Renderings when NullValueHandling=Include, which is the default for Json.net, and used by the recommended Settings.CreateCorrect profile
-//let render ignoreNulls = function
-//    | CaseA { test = null } when ignoreNulls -> """{"case":"CaseA"}"""
-//    | CaseA { test = Q x} -> sprintf """{"case":"CaseA","test":%s}""" x
-//    | CaseB -> """{"case":"CaseB"}"""
-//    | CaseC null when ignoreNulls -> """{"case":"CaseC"}"""
-//    | CaseC (Q s) -> sprintf """{"case":"CaseC","Item":%s}""" s
-//    | CaseD null when ignoreNulls -> """{"case":"CaseD"}"""
-//    | CaseD (Q s) -> sprintf """{"case":"CaseD","a":%s}""" s
-//    | CaseE (null,y) when ignoreNulls -> sprintf """{"case":"CaseE","Item2":%d}""" y
-//    | CaseE (null,y) -> sprintf """{"case":"CaseE","Item1":null,"Item2":%d}""" y
-//    | CaseE (Q x,y) -> sprintf """{"case":"CaseE","Item1":%s,"Item2":%d}""" x y
-//    | CaseF (null,y) when ignoreNulls -> sprintf """{"case":"CaseF","b":%d}""" y
-//    | CaseF (null,y) -> sprintf """{"case":"CaseF","a":null,"b":%d}""" y
-//    | CaseF (Q x,y) -> sprintf """{"case":"CaseF","a":%s,"b":%d}""" x y
-//    | CaseG {Item = null} when ignoreNulls  -> """{"case":"CaseG"}"""
-//    | CaseG {Item = Q s} -> sprintf """{"case":"CaseG","Item":%s}""" s
-//    | CaseH {test = null} when ignoreNulls -> """{"case":"CaseH"}"""
-//    | CaseH {test = Q s} -> sprintf """{"case":"CaseH","test":%s}""" s
-//    | CaseI ({test = null}, null) when ignoreNulls -> """{"case":"CaseI","a":{}}"""
-//    | CaseI ({test = null}, null) -> """{"case":"CaseI","a":{"test":null},"b":null}"""
-//    | CaseI ({test = null}, Q s) when ignoreNulls -> sprintf """{"case":"CaseI","a":{},"b":%s}""" s
-//    | CaseI ({test = null}, Q s) -> sprintf """{"case":"CaseI","a":{"test":null},"b":%s}""" s
-//    | CaseI ({test = Q s}, null) when ignoreNulls -> sprintf """{"case":"CaseI","a":{"test":%s}}""" s
-//    | CaseI ({test = Q s}, null) -> sprintf """{"case":"CaseI","a":{"test":%s},"b":null}""" s
-//    | CaseI ({test = Q s}, Q b) -> sprintf """{"case":"CaseI","a":{"test":%s},"b":%s}""" s b
+let render ignoreNulls = function
+    | CaseA { test = null } when ignoreNulls -> """{"case":"CaseA"}"""
+    | CaseA { test = Q x} -> sprintf """{"case":"CaseA","test":%s}""" x
+    | CaseB -> """{"case":"CaseB"}"""
+    | CaseC null when ignoreNulls -> """{"case":"CaseC"}"""
+    | CaseC (Q s) -> sprintf """{"case":"CaseC","Item":%s}""" s
+    | CaseD null when ignoreNulls -> """{"case":"CaseD"}"""
+    | CaseD (Q s) -> sprintf """{"case":"CaseD","a":%s}""" s
+    | CaseE (null,y) when ignoreNulls -> sprintf """{"case":"CaseE","Item2":%d}""" y
+    | CaseE (null,y) -> sprintf """{"case":"CaseE","Item1":null,"Item2":%d}""" y
+    | CaseE (Q x,y) -> sprintf """{"case":"CaseE","Item1":%s,"Item2":%d}""" x y
+    | CaseF (null,y) when ignoreNulls -> sprintf """{"case":"CaseF","b":%d}""" y
+    | CaseF (null,y) -> sprintf """{"case":"CaseF","a":null,"b":%d}""" y
+    | CaseF (Q x,y) -> sprintf """{"case":"CaseF","a":%s,"b":%d}""" x y
+    | CaseG {Item = null} when ignoreNulls  -> """{"case":"CaseG"}"""
+    | CaseG {Item = Q s} -> sprintf """{"case":"CaseG","Item":%s}""" s
+    | CaseH {test = null} when ignoreNulls -> """{"case":"CaseH"}"""
+    | CaseH {test = Q s} -> sprintf """{"case":"CaseH","test":%s}""" s
+    | CaseI ({test = null}, null) when ignoreNulls -> """{"case":"CaseI","a":{}}"""
+    | CaseI ({test = null}, null) -> """{"case":"CaseI","a":{"test":null},"b":null}"""
+    | CaseI ({test = null}, Q s) when ignoreNulls -> sprintf """{"case":"CaseI","a":{},"b":%s}""" s
+    | CaseI ({test = null}, Q s) -> sprintf """{"case":"CaseI","a":{"test":null},"b":%s}""" s
+    | CaseI ({test = Q s}, null) when ignoreNulls -> sprintf """{"case":"CaseI","a":{"test":%s}}""" s
+    | CaseI ({test = Q s}, null) -> sprintf """{"case":"CaseI","a":{"test":%s},"b":null}""" s
+    | CaseI ({test = Q s}, Q b) -> sprintf """{"case":"CaseI","a":{"test":%s},"b":%s}""" s b
 
-//    | CaseJ x when not x.HasValue && ignoreNulls -> """{"case":"CaseJ"}"""
-//    | CaseJ x when not x.HasValue -> """{"case":"CaseJ","a":null}"""
-//    | CaseJ x -> sprintf """{"case":"CaseJ","a":%d}""" x.Value
-//    | CaseK (a,x) when not x.HasValue && ignoreNulls -> sprintf """{"case":"CaseK","a":%d}""" a
-//    | CaseK (a,x) when not x.HasValue -> sprintf """{"case":"CaseK","a":%d,"b":null}""" a
-//    | CaseK (a,x) -> sprintf """{"case":"CaseK","a":%d,"b":%d}""" a x.Value
-//    | CaseL (a,b) when not a.HasValue && not b.HasValue && ignoreNulls -> """{"case":"CaseL"}"""
-//    | CaseL (a,b) when not a.HasValue && not b.HasValue -> """{"case":"CaseL","a":null,"b":null}"""
-//    | CaseL (a,b) when not a.HasValue && ignoreNulls -> sprintf """{"case":"CaseL","b":%d}""" b.Value
-//    | CaseL (a,b) when not a.HasValue -> sprintf """{"case":"CaseL","a":null,"b":%d}""" b.Value
-//    | CaseL (a,b) when not b.HasValue && ignoreNulls -> sprintf """{"case":"CaseL","a":%d}""" a.Value
-//    | CaseL (a,b) when not b.HasValue -> sprintf """{"case":"CaseL","a":%d,"b":null}""" a.Value
-//    | CaseL (a,b) -> sprintf """{"case":"CaseL","a":%d,"b":%d}""" a.Value b.Value
+    | CaseJ x when not x.HasValue && ignoreNulls -> """{"case":"CaseJ"}"""
+    | CaseJ x when not x.HasValue -> """{"case":"CaseJ","a":null}"""
+    | CaseJ x -> sprintf """{"case":"CaseJ","a":%d}""" x.Value
+    | CaseK (a,x) when not x.HasValue && ignoreNulls -> sprintf """{"case":"CaseK","a":%d}""" a
+    | CaseK (a,x) when not x.HasValue -> sprintf """{"case":"CaseK","a":%d,"b":null}""" a
+    | CaseK (a,x) -> sprintf """{"case":"CaseK","a":%d,"b":%d}""" a x.Value
+    | CaseL (a,b) when not a.HasValue && not b.HasValue && ignoreNulls -> """{"case":"CaseL"}"""
+    | CaseL (a,b) when not a.HasValue && not b.HasValue -> """{"case":"CaseL","a":null,"b":null}"""
+    | CaseL (a,b) when not a.HasValue && ignoreNulls -> sprintf """{"case":"CaseL","b":%d}""" b.Value
+    | CaseL (a,b) when not a.HasValue -> sprintf """{"case":"CaseL","a":null,"b":%d}""" b.Value
+    | CaseL (a,b) when not b.HasValue && ignoreNulls -> sprintf """{"case":"CaseL","a":%d}""" a.Value
+    | CaseL (a,b) when not b.HasValue -> sprintf """{"case":"CaseL","a":%d,"b":null}""" a.Value
+    | CaseL (a,b) -> sprintf """{"case":"CaseL","a":%d,"b":%d}""" a.Value b.Value
 
-//    | CaseM None when ignoreNulls -> """{"case":"CaseM"}"""
-//    | CaseM None -> """{"case":"CaseM","a":null}"""
-//    | CaseM (Some x) -> sprintf """{"case":"CaseM","a":%d}""" x
-//    | CaseN (a,None) when ignoreNulls -> sprintf """{"case":"CaseN","a":%d}""" a
-//    | CaseN (a,None) -> sprintf """{"case":"CaseN","a":%d,"b":null}""" a
-//    | CaseN (a,x) -> sprintf """{"case":"CaseN","a":%d,"b":%d}""" a x.Value
-//    | CaseO (None,None) when ignoreNulls -> """{"case":"CaseO"}"""
-//    | CaseO (None,None) -> """{"case":"CaseO","a":null,"b":null}"""
-//    | CaseO (None,b) when ignoreNulls -> sprintf """{"case":"CaseO","b":%d}""" b.Value
-//    | CaseO (None,b) -> sprintf """{"case":"CaseO","a":null,"b":%d}""" b.Value
-//    | CaseO (a,None) when ignoreNulls -> sprintf """{"case":"CaseO","a":%d}""" a.Value
-//    | CaseO (a,None) -> sprintf """{"case":"CaseO","a":%d,"b":null}""" a.Value
-//    | CaseO (Some a,Some b) -> sprintf """{"case":"CaseO","a":%d,"b":%d}""" a b
-//    | CaseP id -> sprintf """{"case":"CaseP","Item":"%s"}""" id.Value
-//    | CaseQ id -> sprintf """{"case":"CaseQ","Item":"%s"}""" id.Value
-//    | CaseR id -> sprintf """{"case":"CaseR","a":"%s"}""" id.Value
-//    | CaseS id -> sprintf """{"case":"CaseS","a":"%s"}""" id.Value
-//    | CaseT (None, x) when ignoreNulls -> sprintf """{"case":"CaseT","b":"%s"}""" x.Value
-//    | CaseT (None, x) -> sprintf """{"case":"CaseT","a":null,"b":"%s"}""" x.Value
-//    | CaseT (Some x, y) -> sprintf """{"case":"CaseT","a":"%s","b":"%s"}""" x.Value y.Value
-//    | CaseU skus -> sprintf """{"case":"CaseU","Item":[%s]}""" (skus |> Seq.map (fun s -> sprintf "\"%s\"" s.Value) |> String.concat ",")
-//    | CaseV skus -> sprintf """{"case":"CaseV","skus":[%s]}""" (skus |> Seq.map (fun s -> sprintf "\"%s\"" s.Value) |> String.concat ",")
-//    | CaseW (id, skus) -> sprintf """{"case":"CaseW","Item1":"%s","Item2":[%s]}""" id.Value (skus |> Seq.map (fun s -> sprintf "\"%s\"" s.Value) |> String.concat ",")
-//    | CaseX (id, skus) -> sprintf """{"case":"CaseX","a":"%s","skus":[%s]}""" id.Value (skus |> Seq.map (fun s -> sprintf "\"%s\"" s.Value) |> String.concat ",")
-//    | CaseY (a, b) -> sprintf """{"case":"CaseY","a":"%s","b":"%s"}""" (string a) (string b)
-//    | CaseZ (a, None) when ignoreNulls -> sprintf """{"case":"CaseZ","a":"%s"}""" (string a)
-//    | CaseZ (a, None) -> sprintf """{"case":"CaseZ","a":"%s","b":null}""" (string a)
-//    | CaseZ (a, Some b) -> sprintf """{"case":"CaseZ","a":"%s","b":"%s"}""" (string a) (string b)
-//    | CaseZ (a, Some b) -> sprintf """{"case":"CaseZ","a":"%s","b":"%s"}""" (string a) (string b)
+    | CaseM None when ignoreNulls -> """{"case":"CaseM"}"""
+    | CaseM None -> """{"case":"CaseM","a":null}"""
+    | CaseM (Some x) -> sprintf """{"case":"CaseM","a":%d}""" x
+    | CaseN (a,None) when ignoreNulls -> sprintf """{"case":"CaseN","a":%d}""" a
+    | CaseN (a,None) -> sprintf """{"case":"CaseN","a":%d,"b":null}""" a
+    | CaseN (a,x) -> sprintf """{"case":"CaseN","a":%d,"b":%d}""" a x.Value
+    | CaseO (None,None) when ignoreNulls -> """{"case":"CaseO"}"""
+    | CaseO (None,None) -> """{"case":"CaseO","a":null,"b":null}"""
+    | CaseO (None,b) when ignoreNulls -> sprintf """{"case":"CaseO","b":%d}""" b.Value
+    | CaseO (None,b) -> sprintf """{"case":"CaseO","a":null,"b":%d}""" b.Value
+    | CaseO (a,None) when ignoreNulls -> sprintf """{"case":"CaseO","a":%d}""" a.Value
+    | CaseO (a,None) -> sprintf """{"case":"CaseO","a":%d,"b":null}""" a.Value
+    | CaseO (Some a,Some b) -> sprintf """{"case":"CaseO","a":%d,"b":%d}""" a b
+    | CaseP id -> sprintf """{"case":"CaseP","Item":"%s"}""" id.Value
+    | CaseQ id -> sprintf """{"case":"CaseQ","Item":"%s"}""" id.Value
+    | CaseR id -> sprintf """{"case":"CaseR","a":"%s"}""" id.Value
+    | CaseS id -> sprintf """{"case":"CaseS","a":"%s"}""" id.Value
+    | CaseT (None, x) when ignoreNulls -> sprintf """{"case":"CaseT","b":"%s"}""" x.Value
+    | CaseT (None, x) -> sprintf """{"case":"CaseT","a":null,"b":"%s"}""" x.Value
+    | CaseT (Some x, y) -> sprintf """{"case":"CaseT","a":"%s","b":"%s"}""" x.Value y.Value
+    | CaseU skus -> sprintf """{"case":"CaseU","Item":[%s]}""" (skus |> Seq.map (fun s -> sprintf "\"%s\"" s.Value) |> String.concat ",")
+    | CaseV skus -> sprintf """{"case":"CaseV","skus":[%s]}""" (skus |> Seq.map (fun s -> sprintf "\"%s\"" s.Value) |> String.concat ",")
+    | CaseW (id, skus) -> sprintf """{"case":"CaseW","Item1":"%s","Item2":[%s]}""" id.Value (skus |> Seq.map (fun s -> sprintf "\"%s\"" s.Value) |> String.concat ",")
+    | CaseX (id, skus) -> sprintf """{"case":"CaseX","a":"%s","skus":[%s]}""" id.Value (skus |> Seq.map (fun s -> sprintf "\"%s\"" s.Value) |> String.concat ",")
+    | CaseY (a, b) -> sprintf """{"case":"CaseY","a":"%s","b":"%s"}""" (string a) (string b)
+    | CaseZ (a, None) when ignoreNulls -> sprintf """{"case":"CaseZ","a":"%s"}""" (string a)
+    | CaseZ (a, None) -> sprintf """{"case":"CaseZ","a":"%s","b":null}""" (string a)
+    | CaseZ (a, Some b) -> sprintf """{"case":"CaseZ","a":"%s","b":"%s"}""" (string a) (string b)
+    | CaseZ (a, Some b) -> sprintf """{"case":"CaseZ","a":"%s","b":"%s"}""" (string a) (string b)
 
-//type FsCheckGenerators =
-//    static member CartId = Arb.generate |> Gen.map CartId |> Arb.fromGen
-//    static member SkuId = Arb.generate |> Gen.map SkuId |> Arb.fromGen
+type FsCheckGenerators =
+    static member CartId = Arb.generate |> Gen.map CartId |> Arb.fromGen
+    static member SkuId = Arb.generate |> Gen.map SkuId |> Arb.fromGen
 
-//type DomainPropertyAttribute() =
-//    inherit FsCheck.Xunit.PropertyAttribute(QuietOnSuccess = true, Arbitrary=[| typeof<FsCheckGenerators> |])
+type DomainPropertyAttribute() =
+    inherit FsCheck.Xunit.PropertyAttribute(QuietOnSuccess = true, Arbitrary=[| typeof<FsCheckGenerators> |])
 
-//let roundtripProperty ignoreNulls (profile : JsonSerializerSettings) value =
-//    let serialized = JsonConvert.SerializeObject(value, profile)
-//    render ignoreNulls value =! serialized
-//    let deserialized = JsonConvert.DeserializeObject<_>(serialized, profile)
-//    deserialized =! value
+let roundtripProperty ignoreNulls (profile : JsonSerializerOptions) value =
+    let serialized = JsonSerializer.Serialize(value, profile)
+    render ignoreNulls value =! serialized
+    let deserialized = JsonSerializer.Deserialize<_>(serialized, profile)
+    deserialized =! value
 
-//let includeNullsProfile = Settings.CreateDefault(OptionConverter())
-//[<DomainPropertyAttribute(MaxTest=1000)>]
-//let ``UnionConverter ignoreNulls Profile roundtrip property test`` (x: TestDU) =
-//    let ignoreNulls, profile = false, includeNullsProfile
-//    profile.NullValueHandling =! NullValueHandling.Include
-//    roundtripProperty ignoreNulls profile x
+let includeNullsProfile = Options.Create(ignoreNulls = false)
+[<DomainPropertyAttribute(MaxTest=1000)>]
+let ``UnionConverter ignoreNulls Profile roundtrip property test`` (x: TestDU) =
+    let ignoreNulls, profile = false, includeNullsProfile
+    profile.IgnoreNullValues =! false
+    roundtripProperty ignoreNulls profile x
 
-//let defaultProfile = Settings.Create()
-//[<DomainPropertyAttribute(MaxTest=1000)>]
-//let ``UnionConverter opinionated Profile roundtrip property test`` (x: TestDU) =
-//    let ignoreNulls, profile = false, defaultProfile
-//    profile.NullValueHandling =! NullValueHandling.Include
-//    roundtripProperty ignoreNulls profile x
+let defaultProfile = Options.Create ()
+[<DomainPropertyAttribute(MaxTest=1000)>]
+let ``UnionConverter opinionated Profile roundtrip property test`` (x: TestDU) =
+    let ignoreNulls, profile = false, defaultProfile
+    profile.IgnoreNullValues =! false
+    roundtripProperty ignoreNulls profile x
 
 //[<Fact>]
 //let ``Implementation ensures no internal errors escape (which would render a WebApi ModelState.Invalid)`` () =
@@ -305,57 +305,57 @@ let (|Q|) (s: string) = Newtonsoft.Json.JsonConvert.SerializeObject s
 //    test <@ (CaseD "hi") = d @>
 //    test <@ false = gotError @>
 
-//module ``Unmatched case handling`` =
+module ``Unmatched case handling`` =
+    [<Fact>]
+    let ``UnionConverter by default throws on unknown cases`` () =
+        let options = Options.Create(UnionConverter ())
+        let aJson = """{"case":"CaseUnknown"}"""
+        let act () = JsonSerializer.Deserialize<TestDU>(aJson, options)
 
-//    [<Fact>]
-//    let ``UnionConverter by default throws on unknown cases`` () =
-//        let aJson = """{"case":"CaseUnknown"}"""
-//        let act () = JsonConvert.DeserializeObject<TestDU>(aJson, settings)
+        fun (e : System.InvalidOperationException) -> <@ -1 <> e.Message.IndexOf "No case defined for 'CaseUnknown', and no catchAllCase nominated" @>
+        |> raisesWith <@ act() @>
 
-//        fun (e : System.InvalidOperationException) -> <@ -1 <> e.Message.IndexOf "No case defined for 'CaseUnknown', and no catchAllCase nominated" @>
-//        |> raisesWith <@ act() @>
+    type DuWithCatchAll =
+    | Known
+    | Catchall
 
-//    [<JsonConverter(typeof<UnionConverter>, "case", "Catchall")>]
-//    type DuWithCatchAll =
-//    | Known
-//    | Catchall
+    [<Fact>]
+    let ``UnionConverter supports a nominated catchall`` () =
+        let options = Options.Create(UnionConverter<DuWithCatchAll> ("case", "Catchall"))
+        let aJson = """{"case":"CaseUnknown"}"""
+        let a = JsonSerializer.Deserialize<DuWithCatchAll>(aJson, options)
 
-//    [<Fact>]
-//    let ``UnionConverter supports a nominated catchall`` () =
-//        let aJson = """{"case":"CaseUnknown"}"""
-//        let a = JsonConvert.DeserializeObject<DuWithCatchAll>(aJson, settings)
+        test <@ Catchall = a @>
 
-//        test <@ Catchall = a @>
+    type DuWithMissingCatchAll =
+    | Known
 
-//    [<JsonConverter(typeof<UnionConverter>, "case", "CatchAllThatCantBeFound")>]
-//    type DuWithMissingCatchAll =
-//    | Known
+    [<Fact>]
+    let ``UnionConverter explains if nominated catchAll not found`` () =
+        let options = Options.Create(UnionConverter<DuWithMissingCatchAll> ("case", "CatchAllThatCantBeFound"))
+        let aJson = """{"case":"CaseUnknown"}"""
+        let act () = JsonSerializer.Deserialize<DuWithMissingCatchAll>(aJson, options)
 
-//    [<Fact>]
-//    let ``UnionConverter explains if nominated catchAll not found`` () =
-//        let aJson = """{"case":"CaseUnknown"}"""
-//        let act () = JsonConvert.DeserializeObject<DuWithMissingCatchAll>(aJson, settings)
+        fun (e : System.InvalidOperationException) -> <@ -1 <> e.Message.IndexOf "nominated catchAllCase: 'CatchAllThatCantBeFound' not found" @>
+        |> raisesWith <@ act() @>
 
-//        fun (e : System.InvalidOperationException) -> <@ -1 <> e.Message.IndexOf "nominated catchAllCase: 'CatchAllThatCantBeFound' not found" @>
-//        |> raisesWith <@ act() @>
+    //[<NoComparison>] // Forced by usage of JObject
+    //[<JsonConverter(typeof<UnionConverter>, "case", "Catchall")>]
+    //type DuWithCatchAllWithFields =
+    //| Known
+    //| Catchall of Newtonsoft.Json.Linq.JObject
 
-//    [<NoComparison>] // Forced by usage of JObject
-//    [<JsonConverter(typeof<UnionConverter>, "case", "Catchall")>]
-//    type DuWithCatchAllWithFields =
-//    | Known
-//    | Catchall of Newtonsoft.Json.Linq.JObject
+    //[<Fact>]
+    //let ``UnionConverter can feed unknown values into a JObject for logging or post processing`` () =
+    //    let deserialize json = JsonConvert.DeserializeObject<DuWithCatchAllWithFields>(json, settings)
+    //    let jo =
+    //        trap <@ match deserialize """{"case":"CaseUnknown","a":"s","b":1,"c":true}""" with
+    //                | Catchall jo -> jo
+    //                | x -> failwithf "unexpected %A" x @>
 
-//    [<Fact>]
-//    let ``UnionConverter can feed unknown values into a JObject for logging or post processing`` () =
-//        let deserialize json = JsonConvert.DeserializeObject<DuWithCatchAllWithFields>(json, settings)
-//        let jo =
-//            trap <@ match deserialize """{"case":"CaseUnknown","a":"s","b":1,"c":true}""" with
-//                    | Catchall jo -> jo
-//                    | x -> failwithf "unexpected %A" x @>
-
-//        test <@ string jo.["a"]="s"
-//                && jo.["b"].Type=Newtonsoft.Json.Linq.JTokenType.Integer
-//                && jo.["c"].Type=Newtonsoft.Json.Linq.JTokenType.Boolean
-//                && string jo.["case"]="CaseUnknown" @>
-//        let expected  = "{\r\n  \"case\": \"CaseUnknown\",\r\n  \"a\": \"s\",\r\n  \"b\": 1,\r\n  \"c\": true\r\n}".Replace("\r\n",Environment.NewLine)
-//        test <@ expected = string jo @>
+    //    test <@ string jo.["a"]="s"
+    //            && jo.["b"].Type=Newtonsoft.Json.Linq.JTokenType.Integer
+    //            && jo.["c"].Type=Newtonsoft.Json.Linq.JTokenType.Boolean
+    //            && string jo.["case"]="CaseUnknown" @>
+    //    let expected  = "{\r\n  \"case\": \"CaseUnknown\",\r\n  \"a\": \"s\",\r\n  \"b\": 1,\r\n  \"c\": true\r\n}".Replace("\r\n",Environment.NewLine)
+    //    test <@ expected = string jo @>

--- a/tests/FsCodec.SystemTextJson.Tests/UnionConverterTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/UnionConverterTests.fs
@@ -2,7 +2,6 @@
 
 open FsCheck
 open FsCodec.SystemTextJson
-open FsCodec.SystemTextJson.Converters
 open Swensen.Unquote.Assertions
 open System
 open System.IO


### PR DESCRIPTION
WIP reimplementing `FsCodec.NewtonsoftJson.UnionConverter` on `System.Text.Json` re #14 feeding into #38 

## To do
- [x] Ensure basic de/serialization passes, round-tripping
- [x] Ensure upconverting of missing properties to `None`s or `Nullable`s
   (this is covered by existing tests, like [CaseJ](https://github.com/jet/FsCodec/pull/43/files#diff-411eb7e40792e531c572d8729bbfac64R44) and [CaseT](https://github.com/jet/FsCodec/pull/43/files#diff-411eb7e40792e531c572d8729bbfac64R54))
- [ ] Resolve all open review comments