### PR TITLE
UnionConverter: Handle Nested Unions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
+- `UnionConverter`: Handle nested unions [#52](https://github.com/jet/FsCodec/pull/52)
 - `UnionConverter`: Support overriding discriminator without needing to nominate a `catchAllCase` [#51](https://github.com/jet/FsCodec/pull/51)
 
 <a name="2.1.0"></a>

--- a/src/FsCodec.NewtonsoftJson/UnionConverter.fs
+++ b/src/FsCodec.NewtonsoftJson/UnionConverter.fs
@@ -41,6 +41,7 @@ module private Union =
                 || t.GetGenericTypeDefinition().IsValueType)) // Nullable<T>
 
     let typeHasJsonConverterAttribute = memoize (fun (t : Type) -> t.IsDefined(typeof<JsonConverterAttribute>))
+    let typeIsUnionWithConverterAttribute = memoize (fun (t : Type) -> isUnion t && typeHasJsonConverterAttribute t)
 
     let propTypeRequiresConstruction (propertyType : Type) =
         not (isInlinedIntoUnionItem propertyType)
@@ -91,7 +92,7 @@ type UnionConverter private (discriminator : string, ?catchAllCase) =
         writer.WriteValue(case.Name)
 
         match fieldInfos with
-        | [| fi |] when not (Union.typeHasJsonConverterAttribute fi.PropertyType) ->
+        | [| fi |] when not (Union.typeIsUnionWithConverterAttribute fi.PropertyType) ->
             match fieldValues.[0] with
             | null when serializer.NullValueHandling = NullValueHandling.Ignore -> ()
             | fv ->

--- a/src/FsCodec.NewtonsoftJson/UnionConverter.fs
+++ b/src/FsCodec.NewtonsoftJson/UnionConverter.fs
@@ -73,7 +73,7 @@ type UnionConverter private (discriminator : string, ?catchAllCase) =
     inherit JsonConverter()
 
     new() = UnionConverter("case", ?catchAllCase=None)
-    new(discriminator: string) = UnionConverter(discriminator, ?catchAllCase=None)
+    new(discriminator: string) = UnionConverter(discriminator, ?catchAllCase = None)
     new(discriminator: string, catchAllCase: string) = UnionConverter(discriminator, ?catchAllCase=match catchAllCase with null -> None | x -> Some x)
 
     override __.CanConvert (t : Type) = Union.isUnion t

--- a/src/FsCodec.NewtonsoftJson/UnionConverter.fs
+++ b/src/FsCodec.NewtonsoftJson/UnionConverter.fs
@@ -91,7 +91,7 @@ type UnionConverter private (discriminator : string, ?catchAllCase) =
         writer.WriteValue(case.Name)
 
         match fieldInfos with
-        | [| fi |] ->
+        | [| fi |] when not (Union.typeHasJsonConverterAttribute fi.PropertyType) ->
             match fieldValues.[0] with
             | null when serializer.NullValueHandling = NullValueHandling.Ignore -> ()
             | fv ->

--- a/src/FsCodec.NewtonsoftJson/UnionConverter.fs
+++ b/src/FsCodec.NewtonsoftJson/UnionConverter.fs
@@ -73,7 +73,7 @@ type UnionConverter private (discriminator : string, ?catchAllCase) =
     inherit JsonConverter()
 
     new() = UnionConverter("case", ?catchAllCase=None)
-    new(discriminator: string) = UnionConverter(discriminator, ?catchAllCase = None)
+    new(discriminator: string) = UnionConverter(discriminator, ?catchAllCase=None)
     new(discriminator: string, catchAllCase: string) = UnionConverter(discriminator, ?catchAllCase=match catchAllCase with null -> None | x -> Some x)
 
     override __.CanConvert (t : Type) = Union.isUnion t

--- a/src/FsCodec.NewtonsoftJson/UnionConverter.fs
+++ b/src/FsCodec.NewtonsoftJson/UnionConverter.fs
@@ -31,7 +31,7 @@ module private Union =
 
     let getUnion = memoize createUnion
 
-    /// Paralells F# behavior wrt how it generates a DU's underlying .NET Type
+    /// Parallels F# behavior wrt how it generates a DU's underlying .NET Type
     let inline isInlinedIntoUnionItem (t : Type) =
         t = typeof<string>
         || t.IsValueType

--- a/tests/FsCodec.NewtonsoftJson.Tests/UnionConverterTests.fs
+++ b/tests/FsCodec.NewtonsoftJson.Tests/UnionConverterTests.fs
@@ -445,3 +445,8 @@ module Nested =
         let ser = Serdes.Serialize v
         """{"case":"C","Item":{"case2":"EO","Item":null}}""" =! ser
         test <@ v = Serdes.Deserialize ser @>
+
+        let v : U = U.C UUA.S
+        let ser = Serdes.Serialize v
+        """{"case":"C","Item":{"case2":"S"}}""" =! ser
+        test <@ v = Serdes.Deserialize ser @>

--- a/tests/FsCodec.NewtonsoftJson.Tests/UnionConverterTests.fs
+++ b/tests/FsCodec.NewtonsoftJson.Tests/UnionConverterTests.fs
@@ -376,28 +376,35 @@ module Nested =
 
     [<JsonConverter(typeof<UnionConverter>)>]
     type U =
-        | A of {| a : int; b : NU |}
         | B of NU
         | C of UUA
         | D of UU
         | E of E
         | EA of E[]
+        | R of {| a : int; b : NU |}
+        | S
     and [<JsonConverter(typeof<UnionConverter>)>]
         NU =
         | A of string
         | B of int
+        | R of {| a : int; b : NU |}
+        | S
     and [<JsonConverter(typeof<UnionConverter>)>]
         UU =
         | A of string
         | B of int
         | E of E
         | EO of E option
+        | R of {| a: int; b: string |}
+        | S
     and [<JsonConverter(typeof<UnionConverter>, "case2")>]
         UUA =
         | A of string
         | B of int
         | E of E
         | EO of E option
+        | R of {| a: int; b: string |}
+        | S
     and [<JsonConverter(typeof<TypeSafeEnumConverter>)>]
         E =
         | V1

--- a/tests/FsCodec.NewtonsoftJson.Tests/UnionConverterTests.fs
+++ b/tests/FsCodec.NewtonsoftJson.Tests/UnionConverterTests.fs
@@ -378,15 +378,22 @@ module Nested =
     type U =
         | A of {| a : int; b : NU |}
         | B of NU
-        | C of NU2
+        | C of UUA
+        | D of UU
         | E of E
         | EA of E[]
     and [<JsonConverter(typeof<UnionConverter>)>]
         NU =
         | A of string
         | B of int
+    and [<JsonConverter(typeof<UnionConverter>)>]
+        UU =
+        | A of string
+        | B of int
+        | E of E
+        | EO of E option
     and [<JsonConverter(typeof<UnionConverter>, "case2")>]
-        NU2 =
+        UUA =
         | A of string
         | B of int
         | E of E
@@ -401,13 +408,13 @@ module Nested =
         test <@ value = Serdes.Deserialize ser @>
 
     let [<Fact>] ``nesting Unions represents child as item`` () =
-        let v : U = U.C(NU2.B 42)
+        let v : U = U.C(UUA.B 42)
         let ser = Serdes.Serialize v
         """{"case":"C","Item":{"case2":"B","Item":42}}""" =! ser
         test <@ v = Serdes.Deserialize ser @>
 
     let [<Fact>] ``TypeSafeEnum converts direct`` () =
-        let v : U = U.C (NU2.E E.V1)
+        let v : U = U.C (UUA.E E.V1)
         let ser = Serdes.Serialize v
         """{"case":"C","Item":{"case2":"E","Item":"V1"}}""" =! ser
         test <@ v = Serdes.Deserialize ser @>
@@ -422,12 +429,12 @@ module Nested =
         """{"case":"EA","Item":["V2","V2"]}""" =! ser
         test <@ v = Serdes.Deserialize ser @>
 
-        let v : U = U.C (NU2.EO (Some E.V1))
+        let v : U = U.C (UUA.EO (Some E.V1))
         let ser = Serdes.Serialize v
         """{"case":"C","Item":{"case2":"EO","Item":"V1"}}""" =! ser
         test <@ v = Serdes.Deserialize ser @>
 
-        let v : U = U.C (NU2.EO None)
+        let v : U = U.C (UUA.EO None)
         let ser = Serdes.Serialize v
         """{"case":"C","Item":{"case2":"EO","Item":null}}""" =! ser
         test <@ v = Serdes.Deserialize ser @>


### PR DESCRIPTION
Nested unions don't roundtrip; this PR addresses that by removing the inlining of nested objects when a converter is in play