### PR TITLE
change global.json to target .NET Core 3.1 in general, not a specific sdk version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.101"
+    "version": "3.1.101",
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
close #54 

Makes `global.json` compatible with newer versions of the .NET Core 3.1 SDK.