### PR TITLE
Upgrade System.Text.Json to 5.0.0-rc.2.20475.5

### DIFF
--- a/src/FsCodec.SystemTextJson/FsCodec.SystemTextJson.fsproj
+++ b/src/FsCodec.SystemTextJson/FsCodec.SystemTextJson.fsproj
@@ -28,6 +28,7 @@
 
     <PackageReference Include="System.Text.Json" Version="5.0.0-rc.2.20475.5" />
     <PackageReference Include="System.Text.Encodings.Web" Version="5.0.0-rc.2.20475.5" />
+    
     <PackageReference Include="TypeShape" Version="8.0.0" />
   </ItemGroup>
 

--- a/src/FsCodec.SystemTextJson/FsCodec.SystemTextJson.fsproj
+++ b/src/FsCodec.SystemTextJson/FsCodec.SystemTextJson.fsproj
@@ -26,7 +26,8 @@
 
     <PackageReference Include="FSharp.Core" Version="4.3.4" />
 
-    <PackageReference Include="System.Text.Json" Version="5.0.0-preview.3.20214.6" />
+    <PackageReference Include="System.Text.Json" Version="5.0.0-rc.2.20475.5" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="5.0.0-rc.2.20475.5" />
     <PackageReference Include="TypeShape" Version="8.0.0" />
   </ItemGroup>
 

--- a/tests/FsCodec.SystemTextJson.Tests/SerdesTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/SerdesTests.fs
@@ -39,7 +39,7 @@ module StjCharacterization =
 
         let correctSer = """["A,"B"]"""
         raisesWith <@ Serdes.Deserialize<string list>(correctSer, ootbOptions) @>
-            <| fun e -> <@ e.Message.Contains "Deserialization of reference types without a parameterless constructor, a singular parameterized constructor, or a parameterized constructor annotated with 'JsonConstructorAttribute' is not supported. Type 'Microsoft.FSharp.Collections.FSharpList`1[System.String]" @>
+            <| fun e -> <@ e.Message.Contains "The collection type 'Microsoft.FSharp.Collections.FSharpList`1[System.String]' is abstract, an interface, or is read only, and could not be instantiated and populated." @>
 
     // System.Text.Json's JsonSerializerOptions by default escapes HTML-sensitive characters when generating JSON strings
     // while this arguably makes sense as a default


### PR DESCRIPTION
Upgraded `System.Text.Json` to the current latest (5.0.0-rc.2.20475.5) and fixed failing tests. 

Because the tests in `FsCodec.SystemTextJson.Tests` were failing with the following error,

```
System.IO.FileNotFoundException
Could not load file or assembly 'System.Text.Encodings.Web, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'. The system cannot find the file specified.
```

I had to explicitly add a reference to `System.Text.Encodings.Web` under `5.0.0-rc.2.20475.5`.

