### PR TITLE
Enable relaxing of UnionEncoder requireRecordFields

### DIFF
--- a/src/FsCodec.NewtonsoftJson/FsCodec.NewtonsoftJson.fsproj
+++ b/src/FsCodec.NewtonsoftJson/FsCodec.NewtonsoftJson.fsproj
@@ -29,7 +29,6 @@
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Buffers" Version="4.5.0" />
-    <PackageReference Include="TypeShape" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FsCodec.NewtonsoftJson/VerbatimUtf8Converter.fs
+++ b/src/FsCodec.NewtonsoftJson/VerbatimUtf8Converter.fs
@@ -20,5 +20,7 @@ type VerbatimUtf8JsonConverter() =
 
     override __.ReadJson(reader : JsonReader, _ : Type, _ : obj, _ : JsonSerializer) =
         let token = JToken.Load reader
-        if token.Type = JTokenType.Null then null
-        else token |> string |> enc.GetBytes |> box
+        match token.Type with
+        | JTokenType.Null -> null
+        | JTokenType.Float -> reader.Value :?> double |> fun x -> x.ToString "r" |> enc.GetBytes |> box
+        | _ -> token |> string |> enc.GetBytes |> box

--- a/src/FsCodec.SystemTextJson/FsCodec.SystemTextJson.fsproj
+++ b/src/FsCodec.SystemTextJson/FsCodec.SystemTextJson.fsproj
@@ -27,7 +27,6 @@
     <PackageReference Include="FSharp.Core" Version="4.3.4" />
 
     <PackageReference Include="System.Text.Json" Version="5.0.0-preview.3.20214.6" />
-    <PackageReference Include="TypeShape" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FsCodec/FsCodec.fsproj
+++ b/src/FsCodec/FsCodec.fsproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="Internal.fs" />
     <Compile Include="FsCodec.fs" />
     <Compile Include="Codec.fs" />
     <Compile Include="StreamName.fs" />
@@ -21,6 +22,13 @@
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
     <PackageReference Include="FSharp.UMX" Version="1.0.0" />
+    <PackageReference Include="TypeShape" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>FsCodec.NewtonsoftJson</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
 </Project>

--- a/src/FsCodec/Internal.fs
+++ b/src/FsCodec/Internal.fs
@@ -1,0 +1,43 @@
+﻿module internal Internal
+
+open TypeShape.Core
+
+let checkIfSupported<'Contract> requireRecordFields =
+    if not requireRecordFields then
+        let shape =
+            match shapeof<'Contract> with
+            | Shape.FSharpUnion (:? ShapeFSharpUnion<'Contract> as s) -> s
+            | _ ->
+                sprintf "Type '%O' is not an F# union" typeof<'Contract>
+                |> invalidArg "Union"
+        let isAllowed (scase : ShapeFSharpUnionCase<_>) =
+            match scase.Fields with
+            | [| field |] ->
+                match field.Member with
+                // non-primitives
+                | Shape.FSharpRecord _
+                | Shape.Guid _
+
+                // primitives
+                | Shape.Bool _
+                | Shape.Byte _
+                | Shape.SByte _
+                | Shape.Int16 _
+                | Shape.Int32 _
+                | Shape.Int64 _
+                //| Shape.IntPtr _ // unsupported
+                | Shape.UInt16 _
+                | Shape.UInt32 _
+                | Shape.UInt64 _
+                //| Shape.UIntPtr _ // unsupported
+                | Shape.Single _
+                | Shape.Double _
+                | Shape.Char _ -> true
+                | _ -> false
+            | [||] -> true // allows all nullary cases, but a subsequent check is done by UnionContractEncoder.Create with `allowNullaryCases`
+            | _ -> false
+        shape.UnionCases
+        |> Array.tryFind (not << isAllowed)
+        |> function
+        | None -> ()
+        | Some x -> failwithf "The '%s' case has an unsupported type: '%s'" x.CaseInfo.Name x.Fields.[0].Member.Type.FullName


### PR DESCRIPTION
I only did `Newtonsoft.Json` so far because `System.Text.Json` is proving annoying. I'll elaborate further if you like what's here.

Ref: https://github.com/jet/FsCodec/issues/61