### PR TITLE
Fix xmldoc; tidy

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,11 @@
     <TestTargetFrameworks Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' ">net5.0</TestTargetFrameworks>
     <ThisDirAbsolute>$([System.IO.Path]::GetFullPath("$(MSBuildThisFileDirectory)"))</ThisDirAbsolute>
 
+    <WarningLevel>5</WarningLevel>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- Syntax check xmldoc comments-->
+    <WarnOn>3390;$(WarnOn)</WarnOn>
+
     <!-- SourceLink related properties https://github.com/dotnet/SourceLink#using-sourcelink -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/README.md
+++ b/README.md
@@ -238,8 +238,8 @@ The mechanisms in the previous section have proven themselves sufficient for div
 ```fsharp
 type GuidConverter() =
     inherit JsonIsomorphism<Guid, string>()
-    override __.Pickle g = g.ToString "N"
-    override __.UnPickle g = Guid.Parse g
+    override _.Pickle g = g.ToString "N"
+    override _.UnPickle g = Guid.Parse g
 ```
 
 ## `TypeSafeEnumConverter` basic usage
@@ -275,9 +275,9 @@ Here we implement a converter as a JsonIsomorphism to achieve such a mapping
 type OutcomeWithOther = Joy | Pain | Misery | Other
 and OutcomeWithCatchAllConverter() =
     inherit JsonIsomorphism<OutcomeWithOther, string>()
-    override __.Pickle v =
+    override _.Pickle v =
         TypeSafeEnum.toString v
-    override __.UnPickle json =
+    override _.UnPickle json =
         json
         |> TypeSafeEnum.tryParse<OutcomeWithOther>
         |> Option.defaultValue Other

--- a/src/FsCodec.Box/Codec.fs
+++ b/src/FsCodec.Box/Codec.fs
@@ -7,26 +7,26 @@ namespace FsCodec.Box
 open System
 open System.Runtime.InteropServices
 
-/// Provides Codecs that encode and/or extract Event bodies from a stream bearing a set of events defined in terms of a Discriminated Union,
-///   using the conventions implied by using <c>TypeShape.UnionContract.UnionContractEncoder</c>
-/// If you need full control and/or have have your own codecs, see <c>FsCodec.Codec.Create</c> instead
-/// See <a href=""https://github.com/eiriktsarpalis/TypeShape/blob/master/tests/TypeShape.Tests/UnionContractTests.fs"></a> for example usage.
+/// <summary>Provides Codecs that encode and/or extract Event bodies from a stream bearing a set of events defined in terms of a Discriminated Union,
+///   using the conventions implied by using <c>TypeShape.UnionContract.UnionContractEncoder</c><br/>
+/// If you need full control and/or have have your own codecs, see <c>FsCodec.Codec.Create</c> instead.<br/>
+/// See <a href="https://github.com/eiriktsarpalis/TypeShape/blob/master/tests/TypeShape.Tests/UnionContractTests.fs" /> for example usage.</summary>
 type Codec private () =
 
-    /// Generate a <code>IEventEncoder</code> Codec that roundtrips events by holding the boxed form of the Event body.
+    /// <summary>Generate a <code>IEventEncoder</code> Codec that roundtrips events by holding the boxed form of the Event body.<br/>
     /// Uses <c>up</c> and <c>down</c> functions to facilitate upconversion/downconversion
-    ///   and/or surfacing metadata to the Programming Model by including it in the emitted <c>'Event</c>
+    ///   and/or surfacing metadata to the Programming Model by including it in the emitted <c>'Event</c><br/>
     /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or, if unspecified, the Discriminated Union Case Name
-    /// <c>Contract</c> must be tagged with </c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.
+    /// <c>Contract</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.</summary>
     static member Create<'Event, 'Contract, 'Meta, 'Context when 'Contract :> TypeShape.UnionContract.IUnionContract>
-        (   /// Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
-            /// to the <c>'Event</c> representation (typically a Discriminated Union) that is to be presented to the programming model.
+        (   /// <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
+            /// to the <c>'Event</c> representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
             up : FsCodec.ITimelineEvent<obj> * 'Contract -> 'Event,
-            /// Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionContract</c> <c>'Contract</c>
+            /// <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionContract</c> <c>'Contract</c><br/>
             /// The function is also expected to derive a <c>meta</c> object that will be held alongside the data (if it's not <c>None</c>)
-            ///   together with its <c>eventId</c>, <c>correlationId</c>, <c>causationId</c> and an event creation <c>timestamp</c> (defaults to <c>UtcNow</c>).
+            ///   together with its <c>eventId</c>, <c>correlationId</c>, <c>causationId</c> and an event creation <c>timestamp</c> (defaults to <c>UtcNow</c>).</summary>
             down : 'Context option * 'Event -> 'Contract * 'Meta option * Guid * string * string * DateTimeOffset option,
-            /// Enables one to fail encoder generation if 'Contract contains nullary cases. Defaults to <c>false</c>, i.e. permitting them
+            /// <summary>Enables one to fail encoder generation if 'Contract contains nullary cases. Defaults to <c>false</c>, i.e. permitting them</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, obj, 'Context> =
 
@@ -38,33 +38,33 @@ type Codec private () =
                 allowNullaryCases = not (defaultArg rejectNullaryCases false))
 
         { new FsCodec.IEventCodec<'Event, obj, 'Context> with
-            member __.Encode(context, event) =
+            member _.Encode(context, event) =
                 let (c, meta : 'Meta option, eventId, correlationId, causationId, timestamp : DateTimeOffset option) = down (context, event)
                 let enc = dataCodec.Encode c
                 let meta = meta |> Option.map boxEncoder.Encode<'Meta>
                 FsCodec.Core.EventData.Create(enc.CaseName, enc.Payload, defaultArg meta null, eventId, correlationId, causationId, ?timestamp = timestamp)
 
-            member __.TryDecode encoded =
+            member _.TryDecode encoded =
                 let cOption = dataCodec.TryDecode { CaseName = encoded.EventType; Payload = encoded.Data }
                 match cOption with None -> None | Some contract -> let event = up (encoded, contract) in Some event }
 
-    /// Generate an <code>IEventCodec</code> that roundtrips events by holding the boxed form of the Event body.
+    /// <summary>Generate an <c>IEventCodec</c> that roundtrips events by holding the boxed form of the Event body.
     /// Uses <c>up</c> and <c>down</c> and <c>mapCausation</c> functions to facilitate upconversion/downconversion and correlation/causationId mapping
-    ///   and/or surfacing metadata to the Programming Model by including it in the emitted <c>'Event</c>
+    ///   and/or surfacing metadata to the Programming Model by including it in the emitted <c>'Event</c><br/>
     /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name
-    /// <c>Contract</c> must be tagged with </c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.
+    /// <c>Contract</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.</summary>
     static member Create<'Event, 'Contract, 'Meta, 'Context when 'Contract :> TypeShape.UnionContract.IUnionContract>
-        (   /// Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
-            /// to the representation (typically a Discriminated Union) that is to be presented to the programming model.
+        (   /// <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
+            /// to the representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
             up : FsCodec.ITimelineEvent<obj> * 'Contract -> 'Event,
-            /// Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
-            /// The function is also expected to derive
-            ///   a <c>meta</c> object that will be serialized with the same settings (if it's not <c>None</c>)
-            ///   and an Event Creation <c>timestamp</c>.
+            /// <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c><br/>
+            /// The function is also expected to derive:<br>
+            /// - a <c>meta</c> object that will be serialized with the same settings (if it's not <c>None</c>)<br/>
+            /// - and an Event Creation <c>timestamp</c>.<summary>
             down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
-            /// Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>correlationId</c> and c) the correlationId
+            /// <summary>Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>correlationId</c> and c) the correlationId</summary>
             mapCausation : 'Context option * 'Meta option -> 'Meta option * Guid * string * string,
-            /// Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them
+            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, obj, 'Context> =
 
@@ -74,30 +74,30 @@ type Codec private () =
             c, m', eventId, correlationId, causationId, t
         Codec.Create(up = up, down = down, ?rejectNullaryCases = rejectNullaryCases)
 
-    /// Generate an <code>IEventCodec</code> that roundtrips events by holding the boxed form of the Event body.
+    /// <summary>Generate an <code>IEventCodec</code> that roundtrips events by holding the boxed form of the Event body.<br/>
     /// Uses <c>up</c> and <c>down</c> and <c>mapCausation</c> functions to facilitate upconversion/downconversion and correlation/causationId mapping
-    ///   and/or surfacing metadata to the Programming Model by including it in the emitted <c>'Event</c>
+    ///   and/or surfacing metadata to the Programming Model by including it in the emitted <c>'Event</c><br/>
     /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name
-    /// <c>Contract</c> must be tagged with </c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.
+    /// <c>Contract</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.</summary>
     static member Create<'Event, 'Contract, 'Meta when 'Contract :> TypeShape.UnionContract.IUnionContract>
-        (   /// Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
-            /// to the representation (typically a Discriminated Union) that is to be presented to the programming model.
+        (   /// <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
+            /// to the representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
             up : FsCodec.ITimelineEvent<obj> * 'Contract -> 'Event,
-            /// Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
-            /// The function is also expected to derive
-            ///   a <c>meta</c> object that will be serialized with the same settings (if it's not <c>None</c>)
-            ///   and an Event Creation <c>timestamp</c>.
+            /// <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
+            /// The function is also expected to derive:<br/>
+            /// - a <c>meta</c> object that will be serialized with the same settings (if it's not <c>None</c>)<br/>
+            /// - and an Event Creation <c>timestamp</c>.</summary>
             down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
-            /// Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them
+            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, obj, obj> =
 
         let mapCausation (_context : obj, m : 'Meta option) = m, Guid.NewGuid(), null, null
         Codec.Create(up = up, down = down, mapCausation = mapCausation, ?rejectNullaryCases = rejectNullaryCases)
 
-    /// Generate an <code>IEventCodec</code> that roundtrips events by holding the boxed form of the Event body.
+    /// <summary>Generate an <code>IEventCodec</code> that roundtrips events by holding the boxed form of the Event body.<br/>
     /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name
-    /// <c>'Union</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.
+    /// <c>'Union</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.</summary>
     static member Create<'Union when 'Union :> TypeShape.UnionContract.IUnionContract>
         (   /// Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)

--- a/src/FsCodec.Box/FsCodec.Box.fsproj
+++ b/src/FsCodec.Box/FsCodec.Box.fsproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <WarningLevel>5</WarningLevel>
         <IsTestProject>false</IsTestProject>
         <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
         <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>

--- a/src/FsCodec.NewtonsoftJson/FsCodec.NewtonsoftJson.fsproj
+++ b/src/FsCodec.NewtonsoftJson/FsCodec.NewtonsoftJson.fsproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <WarningLevel>5</WarningLevel>
     <IsTestProject>false</IsTestProject>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>

--- a/src/FsCodec.NewtonsoftJson/OptionConverter.fs
+++ b/src/FsCodec.NewtonsoftJson/OptionConverter.fs
@@ -8,9 +8,9 @@ open System
 type OptionConverter() =
     inherit JsonConverter()
 
-    override __.CanConvert(t : Type) = t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<option<_>>
+    override _.CanConvert(t : Type) = t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<option<_>>
 
-    override __.WriteJson(writer : JsonWriter, value : obj, serializer : JsonSerializer) =
+    override _.WriteJson(writer : JsonWriter, value : obj, serializer : JsonSerializer) =
         let value =
             if value = null then null
             else
@@ -19,7 +19,7 @@ type OptionConverter() =
 
         serializer.Serialize(writer, value)
 
-    override __.ReadJson(reader : JsonReader, t : Type, _existingValue : obj, serializer : JsonSerializer) =
+    override _.ReadJson(reader : JsonReader, t : Type, _existingValue : obj, serializer : JsonSerializer) =
         let innerType =
             let innerType = t.GetGenericArguments().[0]
             if innerType.IsValueType then typedefof<Nullable<_>>.MakeGenericType(innerType)

--- a/src/FsCodec.NewtonsoftJson/Pickler.fs
+++ b/src/FsCodec.NewtonsoftJson/Pickler.fs
@@ -33,16 +33,16 @@ type JsonPickler<'T>() =
     abstract Write : writer: JsonWriter * serializer: JsonSerializer * source: 'T  -> unit
     abstract Read : reader: JsonReader * serializer: JsonSerializer -> 'T
 
-    override __.CanConvert t = isMatchingType t
+    override _.CanConvert t = isMatchingType t
 
-    override __.CanRead = true
-    override __.CanWrite = true
+    override _.CanRead = true
+    override _.CanWrite = true
 
-    override __.WriteJson(writer : JsonWriter, value : obj, serializer : JsonSerializer) =
-        __.Write(writer, serializer, value :?> 'T)
+    override x.WriteJson(writer : JsonWriter, value : obj, serializer : JsonSerializer) =
+        x.Write(writer, serializer, value :?> 'T)
 
-    override __.ReadJson(reader : JsonReader, _ : Type, _ : obj, serializer : JsonSerializer) =
-        __.Read(reader, serializer) :> obj
+    override x.ReadJson(reader : JsonReader, _ : Type, _ : obj, serializer : JsonSerializer) =
+        x.Read(reader, serializer) :> obj
 
 /// Json Converter that serializes based on an isomorphic type
 [<AbstractClass>]
@@ -52,16 +52,16 @@ type JsonIsomorphism<'T, 'U>(?targetPickler : JsonPickler<'U>) =
     abstract Pickle   : 'T -> 'U
     abstract UnPickle : 'U -> 'T
 
-    override __.Write(writer : JsonWriter, serializer : JsonSerializer, source : 'T) =
-        let target = __.Pickle source
+    override x.Write(writer : JsonWriter, serializer : JsonSerializer, source : 'T) =
+        let target = x.Pickle source
         match targetPickler with
         | None -> serializer.Serialize(writer, target, typeof<'U>)
         | Some p -> p.Write(writer, serializer, target)
 
-    override __.Read(reader : JsonReader, serializer : JsonSerializer) =
+    override x.Read(reader : JsonReader, serializer : JsonSerializer) =
         let target =
             match targetPickler with
             | None -> serializer.Deserialize<'U>(reader)
             | Some p -> p.Read(reader, serializer)
 
-        __.UnPickle target
+        x.UnPickle target

--- a/src/FsCodec.NewtonsoftJson/Serdes.fs
+++ b/src/FsCodec.NewtonsoftJson/Serdes.fs
@@ -3,13 +3,13 @@ namespace FsCodec.NewtonsoftJson
 open Newtonsoft.Json
 open System.Runtime.InteropServices
 
-/// Serializes to/from strings using the settings arising from a call to <c>Settings.Create()</c>
+/// <summary>Serializes to/from strings using the settings arising from a call to <c>Settings.Create()</c></summary>
 type Serdes private () =
 
     static let defaultSettings = lazy Settings.Create()
     static let indentSettings = lazy Settings.Create(indent = true)
 
-    /// Yields the settings used by <c>Serdes</c> when no <c>settings</c> are supplied.
+    /// <summary>Yields the settings used by <c>Serdes</c> when no <c>settings</c> are supplied.</summary>
     static member DefaultSettings : JsonSerializerSettings = defaultSettings.Value
 
     /// Serializes given value to a JSON string.

--- a/src/FsCodec.NewtonsoftJson/TypeSafeEnumConverter.fs
+++ b/src/FsCodec.NewtonsoftJson/TypeSafeEnumConverter.fs
@@ -35,13 +35,13 @@ module TypeSafeEnum =
 type TypeSafeEnumConverter() =
     inherit JsonConverter()
 
-    override __.CanConvert (t : Type) = TypeSafeEnum.isTypeSafeEnum t
+    override _.CanConvert (t : Type) = TypeSafeEnum.isTypeSafeEnum t
 
-    override __.WriteJson(writer : JsonWriter, value : obj, _ : JsonSerializer) =
+    override _.WriteJson(writer : JsonWriter, value : obj, _ : JsonSerializer) =
         let str = TypeSafeEnum.toString value
         writer.WriteValue str
 
-    override __.ReadJson(reader : JsonReader, t : Type, _ : obj, _ : JsonSerializer) =
+    override _.ReadJson(reader : JsonReader, t : Type, _ : obj, _ : JsonSerializer) =
         if reader.TokenType <> JsonToken.String then
             sprintf "Unexpected token when reading TypeSafeEnum: %O" reader.TokenType |> JsonSerializationException |> raise
         let str = reader.Value :?> string

--- a/src/FsCodec.NewtonsoftJson/UnionConverter.fs
+++ b/src/FsCodec.NewtonsoftJson/UnionConverter.fs
@@ -76,9 +76,9 @@ type UnionConverter private (discriminator : string, ?catchAllCase) =
     new(discriminator: string) = UnionConverter(discriminator, ?catchAllCase=None)
     new(discriminator: string, catchAllCase: string) = UnionConverter(discriminator, ?catchAllCase=match catchAllCase with null -> None | x -> Some x)
 
-    override __.CanConvert (t : Type) = Union.isUnion t
+    override _.CanConvert (t : Type) = Union.isUnion t
 
-    override __.WriteJson(writer : JsonWriter, value : obj, serializer : JsonSerializer) =
+    override _.WriteJson(writer : JsonWriter, value : obj, serializer : JsonSerializer) =
         let union = Union.getUnion (value.GetType())
         let tag = union.tagReader value
         let case = union.cases.[tag]
@@ -112,7 +112,7 @@ type UnionConverter private (discriminator : string, ?catchAllCase) =
 
         writer.WriteEndObject()
 
-    override __.ReadJson(reader : JsonReader, t : Type, _ : obj, serializer : JsonSerializer) =
+    override _.ReadJson(reader : JsonReader, t : Type, _ : obj, serializer : JsonSerializer) =
         let token = JToken.ReadFrom reader
         if token.Type <> JTokenType.Object then raise (FormatException(sprintf "Expected object token, got %O" token.Type))
         let inputJObject = token :?> JObject

--- a/src/FsCodec.NewtonsoftJson/VerbatimUtf8Converter.fs
+++ b/src/FsCodec.NewtonsoftJson/VerbatimUtf8Converter.fs
@@ -10,15 +10,15 @@ type VerbatimUtf8JsonConverter() =
 
     static let enc = System.Text.Encoding.UTF8
 
-    override __.CanConvert(t : Type) =
+    override _.CanConvert(t : Type) =
         typeof<byte[]>.Equals(t)
 
-    override __.WriteJson(writer : JsonWriter, value : obj, serializer : JsonSerializer) =
+    override _.WriteJson(writer : JsonWriter, value : obj, serializer : JsonSerializer) =
         let array = value :?> byte[]
         if array = null || array.Length = 0 then serializer.Serialize(writer, null)
         else writer.WriteRawValue(enc.GetString(array))
 
-    override __.ReadJson(reader : JsonReader, _ : Type, _ : obj, _ : JsonSerializer) =
+    override _.ReadJson(reader : JsonReader, _ : Type, _ : obj, _ : JsonSerializer) =
         let token = JToken.Load reader
         if token.Type = JTokenType.Null then null
         else token |> string |> enc.GetBytes |> box

--- a/src/FsCodec.SystemTextJson/Codec.fs
+++ b/src/FsCodec.SystemTextJson/Codec.fs
@@ -5,12 +5,12 @@ open System.Text.Json
 /// System.Text.Json implementation of TypeShape.UnionContractEncoder's IEncoder that encodes to a `JsonElement`
 type JsonElementEncoder(options : JsonSerializerOptions) =
     interface TypeShape.UnionContract.IEncoder<JsonElement> with
-        member __.Empty = Unchecked.defaultof<_>
+        member _.Empty = Unchecked.defaultof<_>
 
-        member __.Encode(value : 'T) =
+        member _.Encode(value : 'T) =
             JsonSerializer.SerializeToElement(value, options)
 
-        member __.Decode(json : JsonElement) =
+        member _.Decode(json : JsonElement) =
             JsonSerializer.DeserializeElement(json, options)
 
 namespace FsCodec.SystemTextJson
@@ -19,30 +19,30 @@ open System
 open System.Runtime.InteropServices
 open System.Text.Json
 
-/// Provides Codecs that render to a JsonElement suitable for storage in Event Stores based using <c>System.Text.Json</c> and the conventions implied by using
+/// <summary>Provides Codecs that render to a JsonElement suitable for storage in Event Stores based using <c>System.Text.Json</c> and the conventions implied by using
 /// <c>TypeShape.UnionContract.UnionContractEncoder</c> - if you need full control and/or have have your own codecs, see <c>FsCodec.Codec.Create</c> instead
-/// See <a href=""https://github.com/eiriktsarpalis/TypeShape/blob/master/tests/TypeShape.Tests/UnionContractTests.fs"></a> for example usage.
+/// See <a href="https://github.com/eiriktsarpalis/TypeShape/blob/master/tests/TypeShape.Tests/UnionContractTests.fs"></a> for example usage.</summary>
 type Codec private () =
 
     static let defaultOptions = lazy Options.Create()
 
-    /// Generate an <code>IEventCodec</code> using the supplied <c>System.Text.Json<c/> <c>options</c>.
+    /// <summary>Generate an <c>IEventCodec</c> using the supplied <c>System.Text.Json</c> <c>options</c>.<br/>
     /// Uses <c>up</c> and <c>down</c> functions to facilitate upconversion/downconversion
-    ///   and/or surfacing metadata to the Programming Model by including it in the emitted <c>'Event</c>
+    ///   and/or surfacing metadata to the Programming Model by including it in the emitted <c>'Event</c><br/>
     /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name
-    /// <c>Contract</c> must be tagged with </c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.
+    /// <c>Contract</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.</summary>
     static member Create<'Event, 'Contract, 'Meta, 'Context when 'Contract :> TypeShape.UnionContract.IUnionContract>
-        (   /// Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
-            /// to the <c>'Event</c> representation (typically a Discriminated Union) that is to be presented to the programming model.
+        (   /// <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
+            /// to the <c>'Event</c> representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
             up : FsCodec.ITimelineEvent<JsonElement> * 'Contract -> 'Event,
-            /// Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
+            /// <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c><br/>
             /// The function is also expected to derive
             ///   a <c>meta</c> object that will be serialized with the same options (if it's not <c>None</c>)
-            ///   and an Event Creation <c>timestamp</c>.
+            ///   and an Event Creation <c>timestamp</c><summary>.
             down : 'Context option * 'Event -> 'Contract * 'Meta option * Guid * string * string * DateTimeOffset option,
-            /// Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Create()</c>
+            /// <summary>Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Create()</c></summary>
             [<Optional; DefaultParameterValue(null)>] ?options,
-            /// Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them
+            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, JsonElement, 'Context> =
 
@@ -57,36 +57,36 @@ type Codec private () =
                 allowNullaryCases = not (defaultArg rejectNullaryCases false))
 
         { new FsCodec.IEventCodec<'Event, JsonElement, 'Context> with
-            member __.Encode(context, event) =
+            member _.Encode(context, event) =
                 let (c, meta : 'Meta option, eventId, correlationId, causationId, timestamp : DateTimeOffset option) = down (context, event)
                 let enc = dataCodec.Encode c
                 let meta' = match meta with Some x -> elementEncoder.Encode<'Meta> x | None -> Unchecked.defaultof<_>
                 FsCodec.Core.EventData.Create(enc.CaseName, enc.Payload, meta', eventId, correlationId, causationId, ?timestamp = timestamp)
 
-            member __.TryDecode encoded =
+            member _.TryDecode encoded =
                 match dataCodec.TryDecode { CaseName = encoded.EventType; Payload = encoded.Data } with
                 | None -> None
                 | Some contract -> up (encoded, contract) |> Some }
 
-    /// Generate an <code>IEventCodec</code> using the supplied <c>System.Text.Json<c/> <c>options</c>.
+    /// <summary>Generate an <code>IEventCodec</code> using the supplied <c>System.Text.Json</c> <c>options</c>.<br/>
     /// Uses <c>up</c> and <c>down</c> and <c>mapCausation</c> functions to facilitate upconversion/downconversion and correlation/causationId mapping
     ///   and/or surfacing metadata to the Programming Model by including it in the emitted <c>'Event</c>
     /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name
-    /// <c>Contract</c> must be tagged with </c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.
+    /// <c>Contract</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.</summary>
     static member Create<'Event, 'Contract, 'Meta, 'Context when 'Contract :> TypeShape.UnionContract.IUnionContract>
-        (   /// Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
-            /// to the representation (typically a Discriminated Union) that is to be presented to the programming model.
+        (   /// <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
+            /// to the representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
             up : FsCodec.ITimelineEvent<JsonElement> * 'Contract -> 'Event,
-            /// Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
+            /// <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
             /// The function is also expected to derive
             ///   a <c>meta</c> object that will be serialized with the same options (if it's not <c>None</c>)
-            ///   and an Event Creation <c>timestamp</c>.
+            ///   and an Event Creation <c>timestamp</c>.</summary>
             down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
-            /// Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>correlationId</c> and c) the correlationId
+            /// <summary>Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>correlationId</c> and c) the correlationId</summary>
             mapCausation : 'Context option * 'Meta option -> 'Meta option * Guid * string * string,
-            /// Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Create()</c>
+            /// <summary>Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Create()</c></summary>
             [<Optional; DefaultParameterValue(null)>] ?options,
-            /// Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them
+            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, JsonElement, 'Context> =
 
@@ -96,36 +96,36 @@ type Codec private () =
             c, m', eventId, correlationId, causationId, t
         Codec.Create(up = up, down = down, ?options = options, ?rejectNullaryCases = rejectNullaryCases)
 
-    /// Generate an <code>IEventCodec</code> using the supplied <c>System.Text.Json<c/> <c>options</c>.
+    /// <summary>Generate an <code>IEventCodec</code> using the supplied <c>System.Text.Json</c> <c>options</c>.
     /// Uses <c>up</c> and <c>down</c> and <c>mapCausation</c> functions to facilitate upconversion/downconversion and correlation/causationId mapping
     ///   and/or surfacing metadata to the Programming Model by including it in the emitted <c>'Event</c>
     /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name
-    /// <c>Contract</c> must be tagged with </c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.
+    /// <c>Contract</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies</summary>.
     static member Create<'Event, 'Contract, 'Meta when 'Contract :> TypeShape.UnionContract.IUnionContract>
-        (   /// Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
-            /// to the representation (typically a Discriminated Union) that is to be presented to the programming model.
+        (   /// <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
+            /// to the representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
             up : FsCodec.ITimelineEvent<JsonElement> * 'Contract -> 'Event,
-            /// Maps a fresh <c>'Event</c> resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
+            /// <summary>Maps a fresh <c>'Event</c> resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
             /// The function is also expected to derive
             ///   a <c>meta</c> object that will be serialized with the same options (if it's not <c>None</c>)
-            ///   and an Event Creation <c>timestamp</c>.
+            ///   and an Event Creation <c>timestamp</c>.</summary>
             down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
-            /// Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Create()</c>
+            /// <summary>Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Create()</c></summary>
             [<Optional; DefaultParameterValue(null)>] ?options,
-            /// Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them
+            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, JsonElement, obj> =
 
         let mapCausation (_context : obj, m : 'Meta option) = m, Guid.NewGuid(), null, null
         Codec.Create(up = up, down = down, mapCausation = mapCausation, ?options = options, ?rejectNullaryCases = rejectNullaryCases)
 
-    /// Generate an <code>IEventCodec</code> using the supplied <c>System.Text.Json</c> <c>options</c>.
+    /// <summary>Generate an <code>IEventCodec</code> using the supplied <c>System.Text.Json</c> <c>options</c>.
     /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name
-    /// <c>'Union</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.
+    /// <c>'Union</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.</summary>
     static member Create<'Union when 'Union :> TypeShape.UnionContract.IUnionContract>
-        (   // Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Create()</c>
+        (   /// <summary>Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Create()</c></summary>
             [<Optional; DefaultParameterValue(null)>] ?options,
-            /// Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them
+            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Union, JsonElement, obj> =
 

--- a/src/FsCodec.SystemTextJson/FsCodec.SystemTextJson.fsproj
+++ b/src/FsCodec.SystemTextJson/FsCodec.SystemTextJson.fsproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <WarningLevel>5</WarningLevel>
     <IsTestProject>false</IsTestProject>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>

--- a/src/FsCodec.SystemTextJson/Interop.fs
+++ b/src/FsCodec.SystemTextJson/Interop.fs
@@ -11,30 +11,30 @@ type InteropExtensions =
             down : 'To -> 'From) : FsCodec.IEventCodec<'Event, 'To, 'Context> =
 
         { new FsCodec.IEventCodec<'Event, 'To, 'Context> with
-            member __.Encode(context, event) =
+            member _.Encode(context, event) =
                 let encoded = native.Encode(context, event)
                 { new FsCodec.IEventData<_> with
-                    member __.EventType = encoded.EventType
-                    member __.Data = up encoded.Data
-                    member __.Meta = up encoded.Meta
-                    member __.EventId = encoded.EventId
-                    member __.CorrelationId = encoded.CorrelationId
-                    member __.CausationId = encoded.CausationId
-                    member __.Timestamp = encoded.Timestamp }
+                    member _.EventType = encoded.EventType
+                    member _.Data = up encoded.Data
+                    member _.Meta = up encoded.Meta
+                    member _.EventId = encoded.EventId
+                    member _.CorrelationId = encoded.CorrelationId
+                    member _.CausationId = encoded.CausationId
+                    member _.Timestamp = encoded.Timestamp }
 
-            member __.TryDecode encoded =
+            member _.TryDecode encoded =
                 let mapped =
                     { new FsCodec.ITimelineEvent<_> with
-                        member __.Index = encoded.Index
-                        member __.IsUnfold = encoded.IsUnfold
-                        member __.Context = encoded.Context
-                        member __.EventType = encoded.EventType
-                        member __.Data = down encoded.Data
-                        member __.Meta = down encoded.Meta
-                        member __.EventId = encoded.EventId
-                        member __.CorrelationId = encoded.CorrelationId
-                        member __.CausationId = encoded.CausationId
-                        member __.Timestamp = encoded.Timestamp }
+                        member _.Index = encoded.Index
+                        member _.IsUnfold = encoded.IsUnfold
+                        member _.Context = encoded.Context
+                        member _.EventType = encoded.EventType
+                        member _.Data = down encoded.Data
+                        member _.Meta = down encoded.Meta
+                        member _.EventId = encoded.EventId
+                        member _.CorrelationId = encoded.CorrelationId
+                        member _.CausationId = encoded.CausationId
+                        member _.Timestamp = encoded.Timestamp }
                 native.TryDecode mapped }
 
     static member private MapFrom(x : byte[]) : JsonElement =

--- a/src/FsCodec.SystemTextJson/JsonOptionConverter.fs
+++ b/src/FsCodec.SystemTextJson/JsonOptionConverter.fs
@@ -10,12 +10,12 @@ type OptionConverterActivator = delegate of unit -> JsonConverter
 type JsonOptionConverter<'T> () =
     inherit JsonConverter<Option<'T>> ()
 
-    override __.Read(reader, _typ, options) =
+    override _.Read(reader, _typ, options) =
         match reader.TokenType with
         | JsonTokenType.Null -> None
         | _ -> JsonSerializer.Deserialize<'T>(&reader, options) |> Some
 
-    override __.Write(writer, value, options) =
+    override _.Write(writer, value, options) =
         match value with
         | None -> writer.WriteNullValue()
         | Some v -> JsonSerializer.Serialize<'T>(writer, v, options)
@@ -23,10 +23,10 @@ type JsonOptionConverter<'T> () =
 type JsonOptionConverter () =
     inherit JsonConverterFactory()
 
-    override __.CanConvert(t : Type) =
+    override _.CanConvert(t : Type) =
         t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<option<_>>
 
-    override __.CreateConverter (typ, _options) =
+    override _.CreateConverter (typ, _options) =
         let valueType = typ.GetGenericArguments() |> Array.head
         let constructor = typedefof<JsonOptionConverter<_>>.MakeGenericType(valueType).GetConstructors() |> Array.head
         let newExpression = Expression.New(constructor)

--- a/src/FsCodec.SystemTextJson/Pickler.fs
+++ b/src/FsCodec.SystemTextJson/Pickler.fs
@@ -32,10 +32,10 @@ type JsonPickler<'T>() =
 
     abstract Read : reader: byref<Utf8JsonReader> * options: JsonSerializerOptions -> 'T
 
-    override __.CanConvert t = isMatchingType t
+    override _.CanConvert t = isMatchingType t
 
-    override __.Read(reader, _ : Type, opts) =
-        __.Read(&reader, opts)
+    override x.Read(reader, _ : Type, opts) =
+        x.Read(&reader, opts)
 
 /// Json Converter that serializes based on an isomorphic type
 [<AbstractClass>]
@@ -45,16 +45,16 @@ type JsonIsomorphism<'T, 'U>(?targetPickler : JsonPickler<'U>) =
     abstract Pickle   : 'T -> 'U
     abstract UnPickle : 'U -> 'T
 
-    override __.Write(writer, source : 'T, options) =
-        let target = __.Pickle source
+    override x.Write(writer, source : 'T, options) =
+        let target = x.Pickle source
         match targetPickler with
         | None -> JsonSerializer.Serialize(writer, target, options)
         | Some p -> p.Write(writer, target, options)
 
-    override __.Read(reader, options) =
+    override x.Read(reader, options) =
         let target =
             match targetPickler with
             | None -> JsonSerializer.Deserialize<'U>(&reader,options)
             | Some p -> p.Read(&reader, options)
 
-        __.UnPickle target
+        x.UnPickle target

--- a/src/FsCodec.SystemTextJson/TypeSafeEnumConverter.fs
+++ b/src/FsCodec.SystemTextJson/TypeSafeEnumConverter.fs
@@ -42,14 +42,14 @@ module TypeSafeEnum =
 type TypeSafeEnumConverter<'T>() =
     inherit Serialization.JsonConverter<'T>()
 
-    override __.CanConvert(t : Type) =
+    override _.CanConvert(t : Type) =
         t = typedefof<'T> && TypeSafeEnum.isTypeSafeEnum typedefof<'T>
 
-    override __.Write(writer, value, _options) =
+    override _.Write(writer, value, _options) =
         let str = TypeSafeEnum.toString value
         writer.WriteStringValue str
 
-    override __.Read(reader, _t, _options) =
+    override _.Read(reader, _t, _options) =
         if reader.TokenType <> JsonTokenType.String then
             sprintf "Unexpected token when reading TypeSafeEnum: %O" reader.TokenType |> JsonException |> raise
         let str = reader.GetString()

--- a/src/FsCodec/FsCodec.fs
+++ b/src/FsCodec/FsCodec.fs
@@ -18,21 +18,21 @@ type IEventData<'Format> =
     /// <remarks>- For EventStore, this value is not honored when writing; the server applies an authoritative timestamp when accepting the write.</remarks>
     abstract member Timestamp : System.DateTimeOffset
 
-/// Represents a Domain Event or Unfold, together with it's 0-based <c>Index</c> in the event sequence
+/// <summary>Represents a Domain Event or Unfold, together with it's 0-based <c>Index</c> in the event sequence</summary>
 type ITimelineEvent<'Format> =
     inherit IEventData<'Format>
     /// The 0-based index into the event sequence of this Event
     abstract member Index : int64
     /// Application-supplied context related to the origin of this event
     abstract member Context : obj
-    /// Indicates this is not a true Domain Event, but actually an Unfolded Event based on the State inferred from the Events up to and including that at <c>Index</c>
+    /// <summary>Indicates this is not a true Domain Event, but actually an Unfolded Event based on the State inferred from the Events up to and including that at <c>Index</c></summary>
     abstract member IsUnfold : bool
 
-/// Defines an Event Contract interpreter that Encodes and/or Decodes payloads representing the known/relevant set of <c>'Event</c>s borne by a stream Category
+/// <summary>Defines an Event Contract interpreter that Encodes and/or Decodes payloads representing the known/relevant set of <c>'Event</c>s borne by a stream Category</summary>
 type IEventCodec<'Event, 'Format, 'Context> =
-    /// Encodes a <c>'Event</c> instance into a <c>'Format</c> representation
+    /// <summary>Encodes a <c>'Event</c> instance into a <c>'Format</c> representation</summary>
     abstract Encode : context: 'Context option * value: 'Event -> IEventData<'Format>
-    /// Decodes a formatted representation into a <c>'Event<c> instance. Returns <c>None</c> on undefined <c>EventType</c>s
+    /// <summary>Decodes a formatted representation into a <c>'Event</c> instance. Returns <c>None</c> on undefined <c>EventType</c>s</summary>
     abstract TryDecode : encoded: ITimelineEvent<'Format> -> 'Event option
 
 namespace FsCodec.Core
@@ -49,13 +49,13 @@ type EventData<'Format> private (eventType, data, meta, eventId, correlationId, 
         EventData(eventType, data, meta, eventId, correlationId, causationId, match timestamp with Some ts -> ts | None -> DateTimeOffset.UtcNow) :> _
 
     interface FsCodec.IEventData<'Format> with
-        member __.EventType = eventType
-        member __.Data = data
-        member __.Meta = meta
-        member __.EventId = eventId
-        member __.CorrelationId = correlationId
-        member __.CausationId = causationId
-        member __.Timestamp = timestamp
+        member _.EventType = eventType
+        member _.Data = data
+        member _.Meta = meta
+        member _.EventId = eventId
+        member _.CorrelationId = correlationId
+        member _.CausationId = causationId
+        member _.Timestamp = timestamp
 
 /// An Event or Unfold that's been read from a Store and hence has a defined <c>Index</c> on the Event Timeline
 [<NoComparison; NoEquality>]
@@ -67,14 +67,14 @@ type TimelineEvent<'Format> private (index, isUnfold, eventType, data, meta, eve
         let correlationId, causationId = defaultArg correlationId null, defaultArg causationId null
         TimelineEvent(index, isUnfold, eventType, data, meta, eventId, correlationId, causationId, timestamp, context) :> _
 
-    interface FsCodec.ITimelineEvent<'Format> with
-        member __.Index = index
-        member __.IsUnfold = isUnfold
-        member __.Context = context
-        member __.EventType = eventType
-        member __.Data = data
-        member __.Meta = meta
-        member __.EventId = eventId
-        member __.CorrelationId = correlationId
-        member __.CausationId = causationId
-        member __.Timestamp = timestamp
+    interface ITimelineEvent<'Format> with
+        member _.Index = index
+        member _.IsUnfold = isUnfold
+        member _.Context = context
+        member _.EventType = eventType
+        member _.Data = data
+        member _.Meta = meta
+        member _.EventId = eventId
+        member _.CorrelationId = correlationId
+        member _.CausationId = causationId
+        member _.Timestamp = timestamp

--- a/src/FsCodec/FsCodec.fsproj
+++ b/src/FsCodec/FsCodec.fsproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <WarningLevel>5</WarningLevel>
     <IsTestProject>false</IsTestProject>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>

--- a/src/FsCodec/StreamName.fs
+++ b/src/FsCodec/StreamName.fs
@@ -3,10 +3,10 @@ namespace FsCodec
 
 open FSharp.UMX
 
-/// Lightly-wrapped well-formed Stream Name adhering to one of two forms:
-/// 1. <code>{category}-{aggregateId}</code>
-/// 2. <code>{category}-{id1}_{id2}_...{idN}</code>
-// see https://github.com/fsprojects/FSharp.UMX
+/// <summary>Lightly-wrapped well-formed Stream Name adhering to one of two forms:<br/>
+/// 1. <c>{category}-{aggregateId}</c>
+/// 2. <c>{category}-{id1}_{id2}_...{idN}</c><br/>
+/// See <a href="https://github.com/fsprojects/FSharp.UMX" /></summary>
 type StreamName = string<streamName>
 and [<Measure>] streamName
 
@@ -40,8 +40,8 @@ module StreamName =
             buf.Append x |> ignore
         create category (buf.ToString())
 
-    /// Validates and maps a trusted Stream Name consisting of a Category and an Id separated by a '-` (dash)
-    /// Throws <code>InvalidArgumentException</code> if it does not adhere to that form
+    /// <summary>Validates and maps a trusted Stream Name consisting of a Category and an Id separated by a '-` (dash).<br/>
+    /// Throws <c>InvalidArgumentException</c> if it does not adhere to that form.</summary>
     let parse (rawStreamName : string) : StreamName =
         if rawStreamName.IndexOf('-') = -1 then
             invalidArg "streamName" (sprintf "Stream Name '%s' must contain a '-' separator" rawStreamName)
@@ -49,17 +49,17 @@ module StreamName =
 
     (* Parsing: Raw Stream name Validation functions/pattern that handle malformed cases without throwing *)
 
-    /// Attempts to split a Stream Name in the form {category}-{id} into its two elements.
-    /// The {id} segment is permitted to include embedded '-' (dash) characters
-    /// Returns <code>None</code> if it does not adhere to that form.
+    /// <summary>Attempts to split a Stream Name in the form <c>{category}-{id}</c> into its two elements.
+    /// The <c>{id}</c> segment is permitted to include embedded '-' (dash) characters
+    /// Returns <c>None</c> if it does not adhere to that form.</summary>
     let trySplitCategoryAndId (rawStreamName : string) : (string * string) option =
         match rawStreamName.Split(dash, 2) with
         | [| cat; id |] -> Some (cat, id)
         | _ -> None
 
-    /// Attempts to split a Stream Name in the form {category}-{id} into its two elements.
-    /// The {id} segment is permitted to include embedded '-' (dash) characters
-    /// Yields <code>NotCategorized</code> if it does not adhere to that form.
+    /// <summary>Attempts to split a Stream Name in the form <c>{category}-{id}</c> into its two elements.
+    /// The <c>{id}</c> segment is permitted to include embedded '-' (dash) characters
+    /// Yields <c>NotCategorized</c> if it does not adhere to that form.</summary>
     let (|Categorized|NotCategorized|) (rawStreamName : string) : Choice<string * string, unit> =
         match trySplitCategoryAndId rawStreamName with
         | Some catAndId -> Categorized catAndId
@@ -74,35 +74,35 @@ module StreamName =
     (* Splitting: functions/Active patterns for (i.e. generated via `parse`, `create` or `compose`) well-formed Stream Names
        Will throw if presented with malformed strings [generated via alternate means] *)
 
-    /// Splits a well-formed Stream Name of the form {category}-{id} into its two elements.
-    /// Throws <code>InvalidArgumentException</code> if it does not adhere to the well known format (i.e. if it was not produced by `parse`).
-    /// <remarks>Inverse of <code>create</code>
+    /// <summary>Splits a well-formed Stream Name of the form <c>{category}-{id}</c> into its two elements.<br/>
+    /// Throws <c>InvalidArgumentException</c> if it does not adhere to the well known format (i.e. if it was not produced by `parse`).</summary>
+    /// <remarks>Inverse of <c>create</c></remarks>
     let splitCategoryAndId (streamName : StreamName) : string * string =
         let rawName = toString streamName
         match trySplitCategoryAndId rawName with
         | Some catAndId -> catAndId
         | None -> invalidArg (sprintf "Stream Name '%s' must contain a '-' separator" rawName) "streamName"
 
-    /// Splits a well-formed Stream Name of the form {category}-{id} into its two elements
-    /// Throws <c>InvalidArgumentException</c> if the stream name is not well-formed
-    /// <remarks>Inverse of <code>create</code>
+    /// <summary>Splits a well-formed Stream Name of the form <c>{category}-{id}</c> into its two elements.<br/>
+    /// Throws <c>InvalidArgumentException</c> if the stream name is not well-formed.</summary>
+    /// <remarks>Inverse of <c>create</c></remarks>
     let (|CategoryAndId|) : StreamName -> (string * string) = splitCategoryAndId
 
-    /// Splits a `_`-separated set of id elements (as formed by `compose`) into its (one or more) constituent elements.
-    /// <remarks>Inverse of what <code>compose</code> does to the subElements
+    /// <summary>Splits a `_`-separated set of id elements (as formed by `compose`) into its (one or more) constituent elements.</summary>
+    /// <remarks>Inverse of what <code>compose</code> does to the subElements</remarks>
     let (|IdElements|) (aggregateId : string) : string[] =
         aggregateId.Split underscore
 
-    /// Splits a well-formed Stream Name of the form {category}-{id1}_{id2}_{idN} into a pair of category and ids
-    /// Throws <code>InvalidArgumentException</code> if it does not adhere to the well known format (i.e. if it was not produced by `parse`).
-    /// <remarks>Inverse of <code>create</code>
+    /// <summary>Splits a well-formed Stream Name of the form {category}-{id1}_{id2}_{idN} into a pair of category and ids.<br/>
+    /// Throws <c>InvalidArgumentException</c> if it does not adhere to the well known format (i.e. if it was not produced by `parse`).</summary>
+    /// <remarks>Inverse of <c>create</c></remarks>
     let splitCategoryAndIds (streamName : StreamName) : string * string[] =
         let rawName = toString streamName
         match trySplitCategoryAndId rawName with
         | Some (cat, IdElements ids) -> (cat, ids)
         | None -> invalidArg (sprintf "Stream Name '%s' did not contain exactly one '-' separator" rawName) "streamName"
 
-    /// Splits a well-formed Stream Name of the form {category}-{id} into the two elements
-    /// Throws <c>InvalidArgumentException</c> if the stream name is not well-formed
-    /// <remarks>Inverse of <code>create</code>
+    /// <summary>Splits a well-formed Stream Name of the form <c>{category}-{id}</c> into the two elements.<br/>
+    /// Throws <c>InvalidArgumentException</c> if the stream name is not well-formed</summary>
+    /// <remarks>Inverse of <c>create</c></remarks>
     let (|CategoryAndIds|) : StreamName -> (string * string[]) = splitCategoryAndIds

--- a/tests/FsCodec.NewtonsoftJson.Tests/Examples.fsx
+++ b/tests/FsCodec.NewtonsoftJson.Tests/Examples.fsx
@@ -19,7 +19,7 @@ module Contract =
 module Contract2 =
 
     type TypeThatRequiresMyCustomConverter = { mess : int }
-    type MyCustomConverter() = inherit JsonPickler<string>() override __.Read(_,_) = "" override __.Write(_,_,_) = ()
+    type MyCustomConverter() = inherit JsonPickler<string>() override _.Read(_,_) = "" override _.Write(_,_,_) = ()
     type Item = { value : string option; other : TypeThatRequiresMyCustomConverter }
     /// Settings to be used within this contract
     // note OptionConverter is also included by default
@@ -38,8 +38,8 @@ It's recommended to avoid global converters, for at least the following reasons:
 - Explicit is better than implicit *)
 type GuidConverter() =
     inherit JsonIsomorphism<Guid, string>()
-    override __.Pickle g = g.ToString "N"
-    override __.UnPickle g = Guid.Parse g
+    override _.Pickle g = g.ToString "N"
+    override _.UnPickle g = Guid.Parse g
 
 type WithEmbeddedGuid = { a: string; [<Newtonsoft.Json.JsonConverter(typeof<GuidConverter>)>] b: Guid }
 
@@ -82,10 +82,10 @@ Here we implement a converter as a JsonIsomorphism to achieve such a mapping *)
 type OutcomeWithOther = Joy | Pain | Misery | Other
 and OutcomeWithCatchAllConverter() =
     inherit JsonIsomorphism<OutcomeWithOther, string>()
-    override __.Pickle v =
+    override _.Pickle v =
         TypeSafeEnum.toString v
 
-    override __.UnPickle json =
+    override _.UnPickle json =
         json
         |> TypeSafeEnum.tryParse<OutcomeWithOther>
         |> Option.defaultValue Other

--- a/tests/FsCodec.NewtonsoftJson.Tests/Fixtures.fs
+++ b/tests/FsCodec.NewtonsoftJson.Tests/Fixtures.fs
@@ -8,9 +8,9 @@ open System.Runtime.Serialization
 /// Endows any type that inherits this class with standard .NET comparison semantics using a supplied token identifier
 [<AbstractClass>]
 type Comparable<'TComp, 'Token when 'TComp :> Comparable<'TComp, 'Token> and 'Token : comparison>(token : 'Token) =
-    member private __.Token = token // I can haz protected?
+    member private _.Token = token // I can haz protected?
     override x.Equals y = match y with :? Comparable<'TComp, 'Token> as y -> x.Token = y.Token | _ -> false
-    override __.GetHashCode() = hash token
+    override _.GetHashCode() = hash token
     interface IComparable with
         member x.CompareTo y =
             match y with
@@ -23,8 +23,8 @@ type Comparable<'TComp, 'Token when 'TComp :> Comparable<'TComp, 'Token> and 'To
 type SkuId private (id : string) =
     inherit Comparable<SkuId, string>(id)
     [<IgnoreDataMember>] // Prevent swashbuckle inferring there's a "value" field
-    member __.Value = id
-    override __.ToString () = id
+    member _.Value = id
+    override _.ToString () = id
     new (guid: Guid) = SkuId (guid.ToString("N"))
     // NB tests (specifically, empty) lean on having a ctor of this shape
     new() = SkuId(Guid.NewGuid())
@@ -34,9 +34,9 @@ type SkuId private (id : string) =
 and private SkuIdJsonConverter() =
     inherit JsonIsomorphism<SkuId, string>()
     /// Renders as per Guid.ToString("N")
-    override __.Pickle value = value.Value
+    override _.Pickle value = value.Value
     /// Input must be a Guid.Parseable value
-    override __.UnPickle input = SkuId.Parse input
+    override _.UnPickle input = SkuId.Parse input
 
 /// CartId strongly typed id
 [<Sealed; JsonConverter(typeof<CartIdJsonConverter>); AutoSerializable(false); StructuredFormatDisplay("{Value}")>]
@@ -44,8 +44,8 @@ and private SkuIdJsonConverter() =
 type CartId private (id : string) =
     inherit Comparable<CartId, string>(id)
     [<IgnoreDataMember>] // Prevent swashbuckle inferring there's a "value" field
-    member __.Value = id
-    override __.ToString () = id
+    member _.Value = id
+    override _.ToString () = id
     // NB tests lean on having a ctor of this shape
     new (guid: Guid) = CartId (guid.ToString("N"))
     // NB for validation [and XSS] purposes we must prove it translatable to a Guid
@@ -54,6 +54,6 @@ type CartId private (id : string) =
 and private CartIdJsonConverter() =
     inherit JsonIsomorphism<CartId, string>()
     /// Renders as per Guid.ToString("N")
-    override __.Pickle value = value.Value
+    override _.Pickle value = value.Value
     /// Input must be a Guid.Parseable value
-    override __.UnPickle input = CartId.Parse input
+    override _.UnPickle input = CartId.Parse input

--- a/tests/FsCodec.NewtonsoftJson.Tests/FsCodec.NewtonsoftJson.Tests.fsproj
+++ b/tests/FsCodec.NewtonsoftJson.Tests/FsCodec.NewtonsoftJson.Tests.fsproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
-    <WarningLevel>5</WarningLevel>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/FsCodec.NewtonsoftJson.Tests/PicklerTests.fs
+++ b/tests/FsCodec.NewtonsoftJson.Tests/PicklerTests.fs
@@ -21,8 +21,8 @@ open FsCodec.NewtonsoftJson.Tests.Fixtures
 /// </remarks>
 type GuidConverter() =
     inherit JsonIsomorphism<Guid, string>()
-    override __.Pickle g = g.ToString "N"
-    override __.UnPickle g = Guid.Parse g
+    override _.Pickle g = g.ToString "N"
+    override _.UnPickle g = Guid.Parse g
 
 type WithEmbeddedGuid = { a: string; [<JsonConverter(typeof<GuidConverter>)>] b: Guid }
 

--- a/tests/FsCodec.NewtonsoftJson.Tests/UnionConverterTests.fs
+++ b/tests/FsCodec.NewtonsoftJson.Tests/UnionConverterTests.fs
@@ -464,12 +464,12 @@ module IsomorphismUnionEncoder =
         | B of int
     and TopConverter() =
         inherit JsonIsomorphism<Top, Flat<int>>()
-        override __.Pickle value =
+        override _.Pickle value =
             match value with
             | S -> { disc = TS; v = None }
             | N A -> { disc = TA; v = None }
             | N (B v) -> { disc = TB; v = Some v }
-        override __.UnPickle flat =
+        override _.UnPickle flat =
             match flat with
             | { disc = TS } -> S
             | { disc = TA } -> N A

--- a/tests/FsCodec.SystemTextJson.Tests/Examples.fsx
+++ b/tests/FsCodec.SystemTextJson.Tests/Examples.fsx
@@ -30,7 +30,7 @@ module Contract =
 module Contract2 =
 
     type TypeThatRequiresMyCustomConverter = { mess : int }
-    type MyCustomConverter() = inherit JsonPickler<string>() override __.Read(_,_) = "" override __.Write(_,_,_) = ()
+    type MyCustomConverter() = inherit JsonPickler<string>() override _.Read(_,_) = "" override _.Write(_,_,_) = ()
     type Item = { value : string option; other : TypeThatRequiresMyCustomConverter }
     /// Options to be used within this contract; note JsonOptionConverter is also included by default
     let options = FsCodec.SystemTextJson.Options.Create(converters = [| MyCustomConverter() |])
@@ -48,8 +48,8 @@ It's recommended to avoid global converters, for at least the following reasons:
 - Explicit is better than implicit *)
 type GuidConverter() =
     inherit JsonIsomorphism<Guid, string>()
-    override __.Pickle g = g.ToString "N"
-    override __.UnPickle g = Guid.Parse g
+    override _.Pickle g = g.ToString "N"
+    override _.UnPickle g = Guid.Parse g
 
 type WithEmbeddedGuid = { a: string; [<System.Text.Json.Serialization.JsonConverter(typeof<GuidConverter>)>] b: Guid }
 
@@ -92,10 +92,10 @@ Here we implement a converter as a JsonIsomorphism to achieve such a mapping *)
 type OutcomeWithOther = Joy | Pain | Misery | Other
 and OutcomeWithCatchAllConverter() =
     inherit JsonIsomorphism<OutcomeWithOther, string>()
-    override __.Pickle v =
+    override _.Pickle v =
         TypeSafeEnum.toString v
 
-    override __.UnPickle json =
+    override _.UnPickle json =
         json
         |> TypeSafeEnum.tryParse<OutcomeWithOther>
         |> Option.defaultValue Other

--- a/tests/FsCodec.SystemTextJson.Tests/FsCodec.SystemTextJson.Tests.fsproj
+++ b/tests/FsCodec.SystemTextJson.Tests/FsCodec.SystemTextJson.Tests.fsproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <WarningLevel>5</WarningLevel>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/FsCodec.SystemTextJson.Tests/PicklerTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/PicklerTests.fs
@@ -19,8 +19,8 @@ open Xunit
 /// </remarks>
 type GuidConverter() =
     inherit JsonIsomorphism<Guid, string>()
-    override __.Pickle g = g.ToString "N"
-    override __.UnPickle g = Guid.Parse g
+    override _.Pickle g = g.ToString "N"
+    override _.UnPickle g = Guid.Parse g
 
 type WithEmbeddedGuid = { a: string; [<Serialization.JsonConverter(typeof<GuidConverter>)>] b: Guid }
 

--- a/tests/FsCodec.SystemTextJson.Tests/TypeSafeEnumConverterTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/TypeSafeEnumConverterTests.fs
@@ -30,10 +30,10 @@ let [<Fact>] sad () =
 type OutcomeWithOther = Joy | Pain | Misery | Other
 and OutcomeWithCatchAllConverter() =
     inherit JsonIsomorphism<OutcomeWithOther, string>()
-    override __.Pickle v =
+    override _.Pickle v =
         TypeSafeEnum.toString v
 
-    override __.UnPickle json =
+    override _.UnPickle json =
         json
         |> TypeSafeEnum.tryParse<OutcomeWithOther>
         |> Option.defaultValue Other

--- a/tests/FsCodec.Tests/FsCodec.Tests.fsproj
+++ b/tests/FsCodec.Tests/FsCodec.Tests.fsproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
-    <WarningLevel>5</WarningLevel>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
GitHub chokes on malformed xmldoc.
This PR converts my pidgin xmldoc (which I never really expected to work) to syntactically valid xmldoc by wrapping all `///` comments with xmldoc tags within in `<summary>` tags.
Switches on validation of xmldoc at build time for debug and release.
Also includes minor removal of warnings flagged by Rider.