### PR TITLE
Fix stray backtick in comment

### DIFF
--- a/src/FsCodec/StreamName.fs
+++ b/src/FsCodec/StreamName.fs
@@ -40,7 +40,7 @@ module StreamName =
             buf.Append x |> ignore
         create category (buf.ToString())
 
-    /// <summary>Validates and maps a trusted Stream Name consisting of a Category and an Id separated by a '-` (dash).<br/>
+    /// <summary>Validates and maps a trusted Stream Name consisting of a Category and an Id separated by a '-' (dash).<br/>
     /// Throws <c>InvalidArgumentException</c> if it does not adhere to that form.</summary>
     let parse (rawStreamName : string) : StreamName =
         if rawStreamName.IndexOf('-') = -1 then


### PR DESCRIPTION
It was messing up github rendering syntax highlighting of everything after it.
https://github.com/jet/FsCodec/blob/6e867e9815e965f6f4642bfa646e4ab6aa9c6caa/src/FsCodec/StreamName.fs#L40-L47