### PR TITLE
Codec: Add/default to ReadOnlyMemory format instead of byte[]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 
 - `SystemTextJson.CodecJsonElement`: Maps Unions to/from Events with `JsonElement` Bodies as `SystemTextJson.Codec` did in in `2.x` [#75](https://github.com/jet/FsCodec/pull/75)
-- `NewtonsoftJson.ToUtf8Codec`: Adapts the default `NewtonsoftJson.Codec` (which produces `byte[]` bodies), to handle `ReadOnlyMemory<byte>` Event Bodies as per `SystemTextJson.Codec` [#75](https://github.com/jet/FsCodec/pull/75)
-- `SystemTextJson.ToUtf8Codec`: Adapter to map from `JsonElement` to `ReadOnlyMemory<byte>` Event Bodies (for interop scenarios; ideally one uses `SystemTextJson.Codec` dorecly in the first instance) [#75](https://github.com/jet/FsCodec/pull/75)
+- `SystemTextJson.ToUtf8Codec`: Adapter to map from `JsonElement` to `ReadOnlyMemory<byte>` Event Bodies (for interop scenarios; ideally one uses `SystemTextJson.Codec` directly in the first instance) [#75](https://github.com/jet/FsCodec/pull/75)
 
 ### Changed
 
@@ -20,7 +19,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - Updated build and tests to use `net6.0`, all test package dependencies
 - Updated `TypeShape` reference to v `10`, triggering min `FSharp.Core` target moving to `4.5.4` 
 - `SystemTextJson.Codec`: Switched Event body type from `JsonElement` to `ReadOnlyMemory<byte>` [#75](https://github.com/jet/FsCodec/pull/75)
-- `SystemTextJson.ToByteArrayCodec`: now adapts a `ReadOnlyMemory<byte>` encoder (was from `JsonElement`) (to `byte[]` bodies) [#75](https://github.com/jet/FsCodec/pull/75)
+- `NewtonsoftJson.Codec`: Switched Event body type from `byte[]` to `ReadOnlyMemory<byte>` [#75](https://github.com/jet/FsCodec/pull/75)
+- `ToByteArrayCodec`: now adapts a `ReadOnlyMemory<byte>` encoder (was from `JsonElement`) (to `byte[]` bodies); Moved from `FsCodec.SystemTextJson` to `FsCodec.Box` [#75](https://github.com/jet/FsCodec/pull/75)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,18 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `SystemTextJson.CodecJsonElement`: Maps Unions to/from Events with `JsonElement` Bodies as `SystemTextJson.Codec` did in in `2.x` [#75](https://github.com/jet/FsCodec/pull/75)
+- `NewtonsoftJson.ToUtf8Codec`: Adapts the default `NewtonsoftJson.Codec` (which produces `byte[]` bodies), to handle `ReadOnlyMemory<byte>` Event Bodies as per `SystemTextJson.Codec` [#75](https://github.com/jet/FsCodec/pull/75)
+- `SystemTextJson.ToUtf8Codec`: Adapter to map from `JsonElement` to `ReadOnlyMemory<byte>` Event Bodies (for interop scenarios; ideally one uses `SystemTextJson.Codec` dorecly in the first instance) [#75](https://github.com/jet/FsCodec/pull/75)
+
 ### Changed
 
 - `NewtonsoftJson`: Rename `Settings` to `Options` [#60](https://github.com/jet/FsCodec/issues/60) [#76](https://github.com/jet/FsCodec/pull/76)
 - Updated build and tests to use `net6.0`, all test package dependencies
 - Updated `TypeShape` reference to v `10`, triggering min `FSharp.Core` target moving to `4.5.4` 
+- `SystemTextJson.Codec`: Switched Event body type from `JsonElement` to `ReadOnlyMemory<byte>` [#75](https://github.com/jet/FsCodec/pull/75)
+- `SystemTextJson.ToByteArrayCodec`: now adapts a `ReadOnlyMemory<byte>` encoder (was from `JsonElement`) (to `byte[]` bodies) [#75](https://github.com/jet/FsCodec/pull/75)
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ The components within this repository are delivered as multi-targeted Nuget pack
   - [`FsCodec.Codec`](https://github.com/jet/FsCodec/blob/master/src/FsCodec/Codec.fs#L5): enables plugging in a serializer and/or Union Encoder of your choice (typically this is used to supply a pair `encode` and `tryDecode` functions)
   - [`FsCodec.StreamName`](https://github.com/jet/FsCodec/blob/master/src/FsCodec/StreamName.fs): strongly-typed wrapper for a Stream Name, together with factory functions and active patterns for parsing same
 - [![Box Codec NuGet](https://img.shields.io/nuget/v/FsCodec.Box.svg)](https://www.nuget.org/packages/FsCodec.Box/) `FsCodec.Box`: See [`FsCodec.Box.Codec`](#boxcodec); `IEventCodec<obj>` implementation that provides a null encode/decode step in order to enable decoupling of serialization/deserialization concerns from the encoding aspect, typically used together with  [`Equinox.MemoryStore`](https://www.fuget.org/packages/Equinox.MemoryStore)
-  - [depends](https://www.fuget.org/packages/FsCodec.Box) on `FsCodec.Box`
+  - [depends](https://www.fuget.org/packages/FsCodec.Box) on `FsCodec`, `TypeShape >= 10`
 - [![Newtonsoft.Json Codec NuGet](https://img.shields.io/nuget/v/FsCodec.NewtonsoftJson.svg)](https://www.nuget.org/packages/FsCodec.NewtonsoftJson/) `FsCodec.NewtonsoftJson`: As described in [a scheme for the serializing Events modelled as an F# Discriminated Union](https://eiriktsarpalis.wordpress.com/2018/10/30/a-contract-pattern-for-schemaless-datastores/), enabled tagging of F# Discriminated Union cases in a versionable manner with low-dependencies using [TypeShape](https://github.com/eiriktsarpalis/TypeShape)'s [`UnionContractEncoder`](https://eiriktsarpalis.wordpress.com/2018/10/30/a-contract-pattern-for-schemaless-datastores)
   - Uses the ubiquitous [`Newtonsoft.Json`](https://github.com/JamesNK/Newtonsoft.Json) library to serialize the event bodies.
   - Provides relevant Converters for common non-primitive types prevalent in F#
-  - [depends](https://www.fuget.org/packages/FsCodec.NewtonsoftJson) on `FsCodec`, `Newtonsoft.Json >= 11.0.2`, `Microsoft.IO.RecyclableMemoryStream >= 2.2.0`, `System.Buffers >= 4.5.1`
+  - [depends](https://www.fuget.org/packages/FsCodec.NewtonsoftJson) on `FsCodec.Box`, `Newtonsoft.Json >= 11.0.2`, `Microsoft.IO.RecyclableMemoryStream >= 2.2.0`, `System.Buffers >= 4.5.1`
 - [![System.Text.Json Codec NuGet](https://img.shields.io/nuget/v/FsCodec.SystemTextJson.svg)](https://www.nuget.org/packages/FsCodec.SystemTextJson/) `FsCodec.SystemTextJson`: See [#38](https://github.com/jet/FsCodec/pulls/38): drop in replacement that allows one to retarget from `Newtonsoft.Json` to the .NET Core >= v 3.0 default serializer: `System.Text.Json`, solely by changing the referenced namespace.
-  - [depends](https://www.fuget.org/packages/FsCodec.SystemTextJson) on `FsCodec`, `System.Text.Json >= 6.0.1`,
+  - [depends](https://www.fuget.org/packages/FsCodec.SystemTextJson) on `FsCodec.Box`, `System.Text.Json >= 6.0.1`,
 
 # Features: `FsCodec`
 
@@ -724,7 +724,7 @@ which yields the following output:
 <a name="boxcodec"></a>
 # Features: `FsCodec.Box.Codec`
 
-`FsCodec.Box.Codec` is a drop-in-equivalent for `FsCodec.(Newtonsoft|SystemText)Json.Codec` with equivalent `.Create` overloads that encode as `ITimelineEvent<obj>` (as opposed to `ITimelineEvent<byte[]>` / `ITimelineEvent<JsonElement>`).
+`FsCodec.Box.Codec` is a drop-in-equivalent for `FsCodec.(Newtonsoft|SystemText)Json.Codec` with equivalent `.Create` overloads that encode as `ITimelineEvent<obj>` (as opposed to `ITimelineEvent<ReadOnlyMemory<byte>>` / `ITimelineEvent<JsonElement>`).
 
 This is useful when storing events in a `MemoryStore` as it allows one to take the perf cost and ancillary yak shaving induced by round-tripping arbitrary event payloads to the concrete serialization format out of the picture when writing property based unit and integration tests.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Typically used in [applications](https://github.com/jet/dotnet-templates) levera
 
 ## Components
 
-The components within this repository are delivered as multi-targeted Nuget packages supporting `netstandard2.0`/`1` (F# 4.5+) profiles.
+The components within this repository are delivered as multi-targeted Nuget packages supporting `netstandard2.1` (F# 4.5+) profiles.
 
 - [![Codec NuGet](https://img.shields.io/nuget/v/FsCodec.svg)](https://www.nuget.org/packages/FsCodec/) `FsCodec` Defines interfaces with trivial implementation helpers.
   - No dependencies.
@@ -15,13 +15,13 @@ The components within this repository are delivered as multi-targeted Nuget pack
   - [`FsCodec.Codec`](https://github.com/jet/FsCodec/blob/master/src/FsCodec/Codec.fs#L5): enables plugging in a serializer and/or Union Encoder of your choice (typically this is used to supply a pair `encode` and `tryDecode` functions)
   - [`FsCodec.StreamName`](https://github.com/jet/FsCodec/blob/master/src/FsCodec/StreamName.fs): strongly-typed wrapper for a Stream Name, together with factory functions and active patterns for parsing same
 - [![Box Codec NuGet](https://img.shields.io/nuget/v/FsCodec.Box.svg)](https://www.nuget.org/packages/FsCodec.Box/) `FsCodec.Box`: See [`FsCodec.Box.Codec`](#boxcodec); `IEventCodec<obj>` implementation that provides a null encode/decode step in order to enable decoupling of serialization/deserialization concerns from the encoding aspect, typically used together with  [`Equinox.MemoryStore`](https://www.fuget.org/packages/Equinox.MemoryStore)
-  - [depends](https://www.fuget.org/packages/FsCodec.Box) on `FsCodec`, `TypeShape >= 10`
+  - [depends](https://www.fuget.org/packages/FsCodec.Box) on `FsCodec.Box`
 - [![Newtonsoft.Json Codec NuGet](https://img.shields.io/nuget/v/FsCodec.NewtonsoftJson.svg)](https://www.nuget.org/packages/FsCodec.NewtonsoftJson/) `FsCodec.NewtonsoftJson`: As described in [a scheme for the serializing Events modelled as an F# Discriminated Union](https://eiriktsarpalis.wordpress.com/2018/10/30/a-contract-pattern-for-schemaless-datastores/), enabled tagging of F# Discriminated Union cases in a versionable manner with low-dependencies using [TypeShape](https://github.com/eiriktsarpalis/TypeShape)'s [`UnionContractEncoder`](https://eiriktsarpalis.wordpress.com/2018/10/30/a-contract-pattern-for-schemaless-datastores)
   - Uses the ubiquitous [`Newtonsoft.Json`](https://github.com/JamesNK/Newtonsoft.Json) library to serialize the event bodies.
   - Provides relevant Converters for common non-primitive types prevalent in F#
-  - [depends](https://www.fuget.org/packages/FsCodec.NewtonsoftJson) on `FsCodec`, `Newtonsoft.Json >= 11.0.2`, `TypeShape >= 10`, `Microsoft.IO.RecyclableMemoryStream >= 2.2.0`, `System.Buffers >= 4.5.1`
+  - [depends](https://www.fuget.org/packages/FsCodec.NewtonsoftJson) on `FsCodec`, `Newtonsoft.Json >= 11.0.2`, `Microsoft.IO.RecyclableMemoryStream >= 2.2.0`, `System.Buffers >= 4.5.1`
 - [![System.Text.Json Codec NuGet](https://img.shields.io/nuget/v/FsCodec.SystemTextJson.svg)](https://www.nuget.org/packages/FsCodec.SystemTextJson/) `FsCodec.SystemTextJson`: See [#38](https://github.com/jet/FsCodec/pulls/38): drop in replacement that allows one to retarget from `Newtonsoft.Json` to the .NET Core >= v 3.0 default serializer: `System.Text.Json`, solely by changing the referenced namespace.
-  - [depends](https://www.fuget.org/packages/FsCodec.SystemTextJson) on `FsCodec`, `System.Text.Json >= 6.0.1`, `TypeShape >= 10`
+  - [depends](https://www.fuget.org/packages/FsCodec.SystemTextJson) on `FsCodec`, `System.Text.Json >= 6.0.1`,
 
 # Features: `FsCodec`
 

--- a/src/FsCodec.Box/Codec.fs
+++ b/src/FsCodec.Box/Codec.fs
@@ -1,108 +1,83 @@
-/// Fork of FsCodec.NewtonsoftJson.Codec intended to provide equivalent calls and functionality, without actually serializing/deserializing as JSON
-/// This is a useful facility for in-memory stores such as Equinox's MemoryStore as it enables you to
-/// - efficiently test behaviors from an event sourced decision processing perspective (e.g. with Property Based Tests)
-/// - without paying a serialization cost and/or having to deal with sanitization of generated data in order to make it roundtrippable through same
+// Equivalent of FsCodec.Newtonsoft/SystemTextJson.Codec intended to provide equivalent calls and functionality, without actually serializing/deserializing as JSON
+// This is a useful facility for in-memory stores such as Equinox's MemoryStore as it enables you to
+// - efficiently test behaviors from an event sourced decision processing perspective (e.g. with Property Based Tests)
+// - without paying a serialization cost and/or having to deal with sanitization of generated data in order to make it roundtrippable through same
 namespace FsCodec.Box
 
 open System
 open System.Runtime.InteropServices
 
-/// <summary>Provides Codecs that encode and/or extract Event bodies from a stream bearing a set of events defined in terms of a Discriminated Union,
-///   using the conventions implied by using <c>TypeShape.UnionContract.UnionContractEncoder</c><br/>
+/// <summary>Provides Codecs that render to boxed object, ideal for usage in a Memory Store.
+/// Requires that Contract types adhere to the conventions implied by using <c>TypeShape.UnionContract.UnionContractEncoder</c><br/>
 /// If you need full control and/or have have your own codecs, see <c>FsCodec.Codec.Create</c> instead.<br/>
-/// See <a href="https://github.com/eiriktsarpalis/TypeShape/blob/master/tests/TypeShape.Tests/UnionContractTests.fs" /> for example usage.</summary>
+/// See <a href="https://github.com/eiriktsarpalis/TypeShape/blob/master/tests/TypeShape.Tests/UnionContractTests.fs"></a> for example usage.</summary>
 type Codec private () =
 
-    /// <summary>Generate a <code>IEventEncoder</code> Codec that roundtrips events by holding the boxed form of the Event body.<br/>
-    /// Uses <c>up</c> and <c>down</c> functions to facilitate upconversion/downconversion
-    ///   and/or surfacing metadata to the Programming Model by including it in the emitted <c>'Event</c><br/>
-    /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or, if unspecified, the Discriminated Union Case Name
+    static let DefaultEncoder : TypeShape.UnionContract.IEncoder<obj> = TypeShape.UnionContract.BoxEncoder() :> _
+
+    /// <summary>Generate an <c>IEventCodec</c> that handles <c>obj</c> (boxed .NET <c>Object</c>) Event Bodies.<br/>
+    /// Uses <c>up</c>, <c>down</c> functions to handle upconversion/downconversion and eventId/correlationId/causationId mapping
+    ///   and/or surfacing metadata to the programming model by including it in the emitted <c>'Event</c><br/>
+    /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name;
     /// <c>Contract</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.</summary>
     static member Create<'Event, 'Contract, 'Meta, 'Context when 'Contract :> TypeShape.UnionContract.IUnionContract>
         (   /// <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
             /// to the <c>'Event</c> representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
             up : FsCodec.ITimelineEvent<obj> * 'Contract -> 'Event,
-            /// <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionContract</c> <c>'Contract</c><br/>
-            /// The function is also expected to derive a <c>meta</c> object that will be held alongside the data (if it's not <c>None</c>)
-            ///   together with its <c>eventId</c>, <c>correlationId</c>, <c>causationId</c> and an event creation <c>timestamp</c> (defaults to <c>UtcNow</c>).</summary>
+            /// <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c><br/>
+            /// The function is also expected to derive an optional <c>meta</c> object that will be serialized with the same <c>encoder</c>,
+            /// and <c>eventId</c>, <c>correlationId</c>, <c>causationId</c> and an Event Creation<c>timestamp</c></summary>.
             down : 'Context option * 'Event -> 'Contract * 'Meta option * Guid * string * string * DateTimeOffset option,
-            /// <summary>Enables one to fail encoder generation if 'Contract contains nullary cases. Defaults to <c>false</c>, i.e. permitting them</summary>
+            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, obj, 'Context> =
+        Core.Codec.Create(DefaultEncoder, up, down, ?rejectNullaryCases = rejectNullaryCases)
 
-        let boxEncoder : TypeShape.UnionContract.IEncoder<obj> = TypeShape.UnionContract.BoxEncoder() :> _
-        let dataCodec =
-            TypeShape.UnionContract.UnionContractEncoder.Create<'Contract, obj>(
-                boxEncoder,
-                requireRecordFields = true,
-                allowNullaryCases = not (defaultArg rejectNullaryCases false))
-
-        { new FsCodec.IEventCodec<'Event, obj, 'Context> with
-            member _.Encode(context, event) =
-                let (c, meta : 'Meta option, eventId, correlationId, causationId, timestamp : DateTimeOffset option) = down (context, event)
-                let enc = dataCodec.Encode c
-                let meta = meta |> Option.map boxEncoder.Encode<'Meta>
-                FsCodec.Core.EventData.Create(enc.CaseName, enc.Payload, defaultArg meta null, eventId, correlationId, causationId, ?timestamp = timestamp)
-
-            member _.TryDecode encoded =
-                let cOption = dataCodec.TryDecode { CaseName = encoded.EventType; Payload = encoded.Data }
-                match cOption with None -> None | Some contract -> let event = up (encoded, contract) in Some event }
-
-    /// <summary>Generate an <c>IEventCodec</c> that roundtrips events by holding the boxed form of the Event body.
-    /// Uses <c>up</c> and <c>down</c> and <c>mapCausation</c> functions to facilitate upconversion/downconversion and correlation/causationId mapping
-    ///   and/or surfacing metadata to the Programming Model by including it in the emitted <c>'Event</c><br/>
-    /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name
+    /// <summary>Generate an <c>IEventCodec</c> that handles <c>obj</c> (boxed .NET <c>Object</c>) Event Bodies.<br/>
+    /// Uses <c>up</c>, <c>down</c> and <c>mapCausation</c> functions to facilitate upconversion/downconversion and eventId/correlationId/causationId/timestamp mapping
+    ///   and/or surfacing metadata to the programming model by including it in the emitted <c>'Event</c>
+    /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name;
     /// <c>Contract</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.</summary>
     static member Create<'Event, 'Contract, 'Meta, 'Context when 'Contract :> TypeShape.UnionContract.IUnionContract>
         (   /// <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
             /// to the representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
             up : FsCodec.ITimelineEvent<obj> * 'Contract -> 'Event,
-            /// <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c><br/>
-            /// The function is also expected to derive:<br>
-            /// - a <c>meta</c> object that will be serialized with the same settings (if it's not <c>None</c>)<br/>
-            /// - and an Event Creation <c>timestamp</c>.<summary>
+            /// <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
+            /// The function is also expected to derive
+            ///   a <c>meta</c> object that will be serialized with the same options (if it's not <c>None</c>)
+            ///   and an Event Creation <c>timestamp</c>.</summary>
             down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
-            /// <summary>Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>correlationId</c> and c) the correlationId</summary>
+            /// <summary>Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>eventId</c> c) the <c>correlationId</c> and d) the <c>causationId</c></summary>
             mapCausation : 'Context option * 'Meta option -> 'Meta option * Guid * string * string,
-            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them</summary>
+            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, obj, 'Context> =
+        Core.Codec.Create(DefaultEncoder, up, down, mapCausation, ?rejectNullaryCases = rejectNullaryCases)
 
-        let down (context, event) =
-            let c, m, t = down event
-            let m', eventId, correlationId, causationId = mapCausation (context, m)
-            c, m', eventId, correlationId, causationId, t
-        Codec.Create(up = up, down = down, ?rejectNullaryCases = rejectNullaryCases)
-
-    /// <summary>Generate an <code>IEventCodec</code> that roundtrips events by holding the boxed form of the Event body.<br/>
-    /// Uses <c>up</c> and <c>down</c> and <c>mapCausation</c> functions to facilitate upconversion/downconversion and correlation/causationId mapping
-    ///   and/or surfacing metadata to the Programming Model by including it in the emitted <c>'Event</c><br/>
+    /// <summary>Generate an <c>IEventCodec</c> that handles <c>obj</c> (boxed .NET <c>Object</c>) Event Bodies.<br/>
+    /// Uses <c>up</c> and <c>down</c> functions to facilitate upconversion/downconversion/timestamping without eventId/correlation/causationId mapping
+    ///   and/or surfacing metadata to the programming model by including it in the emitted <c>'Event</c>
     /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name
-    /// <c>Contract</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.</summary>
+    /// <c>Contract</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies</summary>.
     static member Create<'Event, 'Contract, 'Meta when 'Contract :> TypeShape.UnionContract.IUnionContract>
         (   /// <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
             /// to the representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
             up : FsCodec.ITimelineEvent<obj> * 'Contract -> 'Event,
-            /// <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
-            /// The function is also expected to derive:<br/>
-            /// - a <c>meta</c> object that will be serialized with the same settings (if it's not <c>None</c>)<br/>
-            /// - and an Event Creation <c>timestamp</c>.</summary>
+            /// <summary>Maps a fresh <c>'Event</c> resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
+            /// The function is also expected to derive
+            ///   a <c>meta</c> object that will be serialized with the same options (if it's not <c>None</c>)
+            ///   and an Event Creation <c>timestamp</c>.</summary>
             down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
             /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, obj, obj> =
+        Core.Codec.Create(DefaultEncoder, up, down, ?rejectNullaryCases = rejectNullaryCases)
 
-        let mapCausation (_context : obj, m : 'Meta option) = m, Guid.NewGuid(), null, null
-        Codec.Create(up = up, down = down, mapCausation = mapCausation, ?rejectNullaryCases = rejectNullaryCases)
-
-    /// <summary>Generate an <code>IEventCodec</code> that roundtrips events by holding the boxed form of the Event body.<br/>
+    /// <summary>Generate an <c>IEventCodec</c> that handles <c>obj</c> (boxed .NET <c>Object</c>) Event Bodies.<br/>
     /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name
     /// <c>'Union</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.</summary>
     static member Create<'Union when 'Union :> TypeShape.UnionContract.IUnionContract>
-        (   /// Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them
+        (   /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Union, obj, obj> =
-
-        let up : FsCodec.ITimelineEvent<_> * 'Union -> 'Union = snd
-        let down (event : 'Union) = event, None, None
-        Codec.Create(up = up, down = down, ?rejectNullaryCases = rejectNullaryCases)
+        Core.Codec.Create(DefaultEncoder, ?rejectNullaryCases = rejectNullaryCases)

--- a/src/FsCodec.Box/Codec.fs
+++ b/src/FsCodec.Box/Codec.fs
@@ -1,4 +1,4 @@
-// Equivalent of FsCodec.Newtonsoft/SystemTextJson.Codec intended to provide equivalent calls and functionality, without actually serializing/deserializing as JSON
+// Equivalent of FsCodec.NewtonsoftJson/SystemTextJson.Codec intended to provide equivalent calls and functionality, without actually serializing/deserializing as JSON
 // This is a useful facility for in-memory stores such as Equinox's MemoryStore as it enables you to
 // - efficiently test behaviors from an event sourced decision processing perspective (e.g. with Property Based Tests)
 // - without paying a serialization cost and/or having to deal with sanitization of generated data in order to make it roundtrippable through same

--- a/src/FsCodec.Box/CoreCodec.fs
+++ b/src/FsCodec.Box/CoreCodec.fs
@@ -1,7 +1,6 @@
-namespace FsCodec.SystemTextJson.Core
+namespace FsCodec.Box.Core
 
 open System
-open System.Text.Json
 open System.Runtime.InteropServices
 
 /// <summary>Low-level Codec Generator that encodes to a Generic Event <c>'Body</c> Type.

--- a/src/FsCodec.Box/FsCodec.Box.fsproj
+++ b/src/FsCodec.Box/FsCodec.Box.fsproj
@@ -1,13 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
         <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
     </PropertyGroup>
 
     <ItemGroup>
+        <Compile Include="CoreCodec.fs" />
         <Compile Include="Codec.fs" />
+        <Compile Include="Interop.fs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/FsCodec.Box/Interop.fs
+++ b/src/FsCodec.Box/Interop.fs
@@ -1,0 +1,53 @@
+namespace FsCodec.Interop
+
+open System.Runtime.CompilerServices
+open System
+
+[<Extension>]
+type InteropExtensions =
+
+    static member public Adapt<'From, 'To, 'Event, 'Context>
+        (   native : FsCodec.IEventCodec<'Event, 'From, 'Context>,
+            up : 'From -> 'To,
+            down : 'To -> 'From) : FsCodec.IEventCodec<'Event, 'To, 'Context> =
+
+        { new FsCodec.IEventCodec<'Event, 'To, 'Context> with
+            member _.Encode(context, event) =
+                let encoded = native.Encode(context, event)
+                { new FsCodec.IEventData<_> with
+                    member _.EventType = encoded.EventType
+                    member _.Data = up encoded.Data
+                    member _.Meta = up encoded.Meta
+                    member _.EventId = encoded.EventId
+                    member _.CorrelationId = encoded.CorrelationId
+                    member _.CausationId = encoded.CausationId
+                    member _.Timestamp = encoded.Timestamp }
+
+            member _.TryDecode encoded =
+                let mapped =
+                    { new FsCodec.ITimelineEvent<_> with
+                        member _.Index = encoded.Index
+                        member _.IsUnfold = encoded.IsUnfold
+                        member _.Context = encoded.Context
+                        member _.EventType = encoded.EventType
+                        member _.Data = down encoded.Data
+                        member _.Meta = down encoded.Meta
+                        member _.EventId = encoded.EventId
+                        member _.CorrelationId = encoded.CorrelationId
+                        member _.CausationId = encoded.CausationId
+                        member _.Timestamp = encoded.Timestamp }
+                native.TryDecode mapped }
+
+    static member private BytesToReadOnlyMemory(x : byte[]) : ReadOnlyMemory<byte> =
+        if x = null then ReadOnlyMemory.Empty
+        else ReadOnlyMemory x
+    static member private ReadOnlyMemoryToBytes(x : ReadOnlyMemory<byte>) : byte[] =
+        if x.IsEmpty then null
+        else x.ToArray()
+
+    /// Adapt an IEventCodec that handles ReadOnlyMemory<byte> Event Bodies to instead use byte[]
+    /// Ideally not used as it makes pooling problematic; only provided for interop/porting scaffolding wrt Equinox V3 and EventStore.Client etc
+    [<Extension>]
+    static member ToByteArrayCodec<'Event, 'Context>(native : FsCodec.IEventCodec<'Event, ReadOnlyMemory<byte>, 'Context>)
+        : FsCodec.IEventCodec<'Event, byte[], 'Context> =
+        InteropExtensions.Adapt(native, InteropExtensions.ReadOnlyMemoryToBytes, InteropExtensions.BytesToReadOnlyMemory)

--- a/src/FsCodec.NewtonsoftJson/Codec.fs
+++ b/src/FsCodec.NewtonsoftJson/Codec.fs
@@ -24,7 +24,7 @@ module private Utf8BytesEncoder =
         new MemoryStream(json, writable = false)
     let makeJsonReader(ms : MemoryStream) =
         new JsonTextReader(new StreamReader(ms), ArrayPool = CharBuffersPool.instance)
-    let private utf8NoBom = new System.Text.UTF8Encoding(false, true)
+    let private utf8NoBom = System.Text.UTF8Encoding(false, true)
     let makeJsonWriter ms =
         // We need to `leaveOpen` in order to allow .Dispose of the `.rentStream`'d to return it
         let sw = new StreamWriter(ms, utf8NoBom, 1024, leaveOpen = true) // same middle args as StreamWriter default ctor
@@ -54,8 +54,6 @@ module Core =
 /// See <a href="https://github.com/eiriktsarpalis/TypeShape/blob/master/tests/TypeShape.Tests/UnionContractTests.fs" /> for example usage.</summary>
 type Codec private () =
 
-    static let defaultSettings = lazy Options.Create()
-
     /// <summary>Generate an <code>IEventCodec</code> using the supplied <c>Newtonsoft.Json</c> <c>settings</c>.<br/>
     /// Uses <c>up</c> and <c>down</c> functions to facilitate upconversion/downconversion
     ///   and/or surfacing metadata to the Programming Model by including it in the emitted <c>'Event</c><br/>
@@ -76,8 +74,8 @@ type Codec private () =
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, byte[], 'Context> =
 
-        let settings = match settings with Some x -> x | None -> defaultSettings.Value
-        let bytesEncoder : TypeShape.UnionContract.IEncoder<_> = new Core.BytesEncoder(settings) :> _
+        let settings = match settings with Some x -> x | None -> Options.Default
+        let bytesEncoder : TypeShape.UnionContract.IEncoder<_> = Core.BytesEncoder(settings) :> _
         let dataCodec =
             TypeShape.UnionContract.UnionContractEncoder.Create<'Contract, byte[]>(
                 bytesEncoder,
@@ -116,7 +114,7 @@ type Codec private () =
             down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
             /// <summary>Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>correlationId</c> and c) the correlationId</summary>
             mapCausation : 'Context option * 'Meta option -> 'Meta option * Guid * string * string,
-            /// <summary>Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c></summary>
+            /// <summary>Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to <c>Options.Default</c></summary>
             [<Optional; DefaultParameterValue(null)>] ?settings,
             /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
@@ -142,7 +140,7 @@ type Codec private () =
             ///   a <c>meta</c> object that will be serialized with the same settings (if it's not <c>None</c>)
             ///   and an Event Creation <c>timestamp</c>.</summary>
             down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
-            /// <summary>Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c></summary>
+            /// <summary>Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to <c>Options.Default</c></summary>
             [<Optional; DefaultParameterValue(null)>] ?settings,
             /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)

--- a/src/FsCodec.NewtonsoftJson/Codec.fs
+++ b/src/FsCodec.NewtonsoftJson/Codec.fs
@@ -18,10 +18,10 @@ module private CharBuffersPool =
 module private Utf8BytesEncoder =
     let private streamManager = Microsoft.IO.RecyclableMemoryStreamManager()
     let rentStream () = streamManager.GetStream("bytesEncoder")
-    let wrapAsStream json =
+    let wrapAsStream (utf8json : ReadOnlyMemory<byte>) =
         // This is the most efficient way of approaching this without using Spans etc.
         // RecyclableMemoryStreamManager does not have any wins to provide us
-        new MemoryStream(json, writable = false)
+        new MemoryStream(utf8json.ToArray(), writable = false)
     let makeJsonReader(ms : MemoryStream) =
         new JsonTextReader(new StreamReader(ms), ArrayPool = CharBuffersPool.instance)
     let private utf8NoBom = System.Text.UTF8Encoding(false, true)
@@ -34,131 +34,104 @@ module Core =
     /// Newtonsoft.Json implementation of TypeShape.UnionContractEncoder's IEncoder that encodes direct to a UTF-8 Buffer
     type BytesEncoder(settings : JsonSerializerSettings) =
         let serializer = JsonSerializer.Create(settings)
-        interface TypeShape.UnionContract.IEncoder<byte[]> with
-            member _.Empty = Unchecked.defaultof<_>
+        interface TypeShape.UnionContract.IEncoder<ReadOnlyMemory<byte>> with
+            member _.Empty = ReadOnlyMemory.Empty
 
             member _.Encode (value : 'T) =
                 use ms = Utf8BytesEncoder.rentStream ()
                 (   use jsonWriter = Utf8BytesEncoder.makeJsonWriter ms
                     serializer.Serialize(jsonWriter, value, typeof<'T>))
                 // TOCONSIDER as noted in the comments on RecyclableMemoryStream.ToArray, ideally we'd be continuing the rental and passing out a Span
-                ms.ToArray()
+                ms.ToArray() |> ReadOnlyMemory
 
-            member _.Decode(json : byte[]) =
-                use ms = Utf8BytesEncoder.wrapAsStream json
+            member _.Decode(utf8json : ReadOnlyMemory<byte>) =
+                use ms = Utf8BytesEncoder.wrapAsStream utf8json
                 use jsonReader = Utf8BytesEncoder.makeJsonReader ms
                 serializer.Deserialize<'T>(jsonReader)
 
-/// <summary>Provides Codecs that render to a UTF-8 array suitable for storage in Event Stores based using <c>Newtonsoft.Json</c> and the conventions implied by using
-/// <c>TypeShape.UnionContract.UnionContractEncoder</c> - if you need full control and/or have have your own codecs, see <c>FsCodec.Codec.Create</c> instead
-/// See <a href="https://github.com/eiriktsarpalis/TypeShape/blob/master/tests/TypeShape.Tests/UnionContractTests.fs" /> for example usage.</summary>
+/// <summary>Provides Codecs that render to a <c>ReadOnlyMemory&lt;byte&gt;</c>, suitable for storage in Event Stores that handle Event Data and Metadata as opaque blobs.
+/// Requires that Contract types adhere to the conventions implied by using <c>TypeShape.UnionContract.UnionContractEncoder</c><br/>
+/// If you need full control and/or have have your own codecs, see <c>FsCodec.Codec.Create</c> instead.<br/>
+/// See <a href="https://github.com/eiriktsarpalis/TypeShape/blob/master/tests/TypeShape.Tests/UnionContractTests.fs"></a> for example usage.</summary>
 type Codec private () =
 
-    /// <summary>Generate an <code>IEventCodec</code> using the supplied <c>Newtonsoft.Json</c> <c>settings</c>.<br/>
-    /// Uses <c>up</c> and <c>down</c> functions to facilitate upconversion/downconversion
-    ///   and/or surfacing metadata to the Programming Model by including it in the emitted <c>'Event</c><br/>
-    /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name
+    static let DefaultEncoder : Lazy<TypeShape.UnionContract.IEncoder<ReadOnlyMemory<byte>>> = lazy (Core.BytesEncoder Options.Default :> _)
+
+    static let mkEncoder : JsonSerializerSettings option -> TypeShape.UnionContract.IEncoder<ReadOnlyMemory<byte>> = function
+        | None -> DefaultEncoder.Value
+        | Some opts -> Core.BytesEncoder opts :> _
+
+    /// <summary>Generate an <c>IEventCodec</c> that handles <c>ReadOnlyMemory&lt;byte&gt;</c> Event Bodies using the supplied <c>Newtonsoft.Json.JsonSerializerSettings</c> <c>options</c>.<br/>
+    /// Uses <c>up</c>, <c>down</c> functions to handle upconversion/downconversion and eventId/correlationId/causationId mapping
+    ///   and/or surfacing metadata to the programming model by including it in the emitted <c>'Event</c><br/>
+    /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name;
     /// <c>Contract</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.</summary>
     static member Create<'Event, 'Contract, 'Meta, 'Context when 'Contract :> TypeShape.UnionContract.IUnionContract>
         (   /// <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
             /// to the <c>'Event</c> representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
-            up : FsCodec.ITimelineEvent<byte[]> * 'Contract -> 'Event,
-            /// <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
-            /// The function is also expected to derive
-            ///   a <c>meta</c> object that will be serialized with the same settings (if it's not <c>None</c>)
-            ///   and an Event Creation <c>timestamp</c>.</summary>
+            up : FsCodec.ITimelineEvent<ReadOnlyMemory<byte>> * 'Contract -> 'Event,
+            /// <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c><br/>
+            /// The function is also expected to derive an optional <c>meta</c> object that will be serialized with the same <c>encoder</c>,
+            /// and <c>eventId</c>, <c>correlationId</c>, <c>causationId</c> and an Event Creation<c>timestamp</c></summary>.
             down : 'Context option * 'Event -> 'Contract * 'Meta option * Guid * string * string * DateTimeOffset option,
             /// <summary>Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c></summary>
-            [<Optional; DefaultParameterValue(null)>] ?settings,
-            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them</summary>
+            [<Optional; DefaultParameterValue(null)>] ?options,
+            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
-        : FsCodec.IEventCodec<'Event, byte[], 'Context> =
+        : FsCodec.IEventCodec<'Event, ReadOnlyMemory<byte>, 'Context> =
+        FsCodec.Box.Core.Codec.Create(mkEncoder options, up, down, ?rejectNullaryCases = rejectNullaryCases)
 
-        let settings = match settings with Some x -> x | None -> Options.Default
-        let bytesEncoder : TypeShape.UnionContract.IEncoder<_> = Core.BytesEncoder(settings) :> _
-        let dataCodec =
-            TypeShape.UnionContract.UnionContractEncoder.Create<'Contract, byte[]>(
-                bytesEncoder,
-                // For now, we hard wire in disabling of non-record bodies as:
-                // a) it's extra yaks to shave
-                // b) it's questionable whether allowing one to define event contracts that preclude adding extra fields is a useful idea in the first instance
-                // See VerbatimUtf8EncoderTests.fs and InteropTests.fs - there are edge cases when `d` fields have null / zero-length / missing values
-                requireRecordFields = true,
-                allowNullaryCases = not (defaultArg rejectNullaryCases false))
-
-        { new FsCodec.IEventCodec<'Event, byte[], 'Context> with
-            member _.Encode(context, event) =
-                let (c, meta : 'Meta option, eventId, correlationId, causationId, timestamp : DateTimeOffset option) = down (context, event)
-                let enc = dataCodec.Encode c
-                let metaUtf8 = match meta with Some x -> bytesEncoder.Encode<'Meta> x | None -> null
-                FsCodec.Core.EventData.Create(enc.CaseName, enc.Payload, metaUtf8, eventId, correlationId, causationId, ?timestamp = timestamp)
-
-            member _.TryDecode encoded =
-                match dataCodec.TryDecode { CaseName = encoded.EventType; Payload = encoded.Data } with
-                | None -> None
-                | Some contract -> up (encoded, contract) |> Some }
-
-    /// <summary>Generate an <code>IEventCodec</code> using the supplied <c>Newtonsoft.Json</c> <c>settings</c>.
-    /// Uses <c>up</c> and <c>down</c> and <c>mapCausation</c> functions to facilitate upconversion/downconversion and correlation/causationId mapping
-    ///   and/or surfacing metadata to the Programming Model by including it in the emitted <c>'Event</c>
-    /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name
+    /// <summary>Generate an <c>IEventCodec</c> that handles <c>ReadOnlyMemory&lt;byte&gt;</c> Event Bodies using the supplied <c>Newtonsoft.Json.JsonSerializerSettings</c> <c>options</c>.<br/>
+    /// Uses <c>up</c>, <c>down</c> and <c>mapCausation</c> functions to facilitate upconversion/downconversion and eventId/correlationId/causationId/timestamp mapping
+    ///   and/or surfacing metadata to the programming model by including it in the emitted <c>'Event</c>
+    /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name;
     /// <c>Contract</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.</summary>
     static member Create<'Event, 'Contract, 'Meta, 'Context when 'Contract :> TypeShape.UnionContract.IUnionContract>
         (   /// <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
             /// to the representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
-            up : FsCodec.ITimelineEvent<byte[]> * 'Contract -> 'Event,
+            up : FsCodec.ITimelineEvent<ReadOnlyMemory<byte>> * 'Contract -> 'Event,
             /// <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
             /// The function is also expected to derive
-            ///   a <c>meta</c> object that will be serialized with the same settings (if it's not <c>None</c>)
+            ///   a <c>meta</c> object that will be serialized with the same options (if it's not <c>None</c>)
             ///   and an Event Creation <c>timestamp</c>.</summary>
             down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
-            /// <summary>Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>correlationId</c> and c) the correlationId</summary>
+            /// <summary>Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>eventId</c> c) the <c>correlationId</c> and d) the <c>causationId</c></summary>
             mapCausation : 'Context option * 'Meta option -> 'Meta option * Guid * string * string,
-            /// <summary>Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to <c>Options.Default</c></summary>
-            [<Optional; DefaultParameterValue(null)>] ?settings,
-            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them</summary>
+            /// <summary>Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c></summary>
+            [<Optional; DefaultParameterValue(null)>] ?options,
+            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
-        : FsCodec.IEventCodec<'Event, byte[], 'Context> =
+        : FsCodec.IEventCodec<'Event, ReadOnlyMemory<byte>, 'Context> =
+        FsCodec.Box.Core.Codec.Create(mkEncoder options, up, down, mapCausation, ?rejectNullaryCases = rejectNullaryCases)
 
-        let down (context, union) =
-            let c, m, t = down union
-            let m', eventId, correlationId, causationId = mapCausation (context, m)
-            c, m', eventId, correlationId, causationId, t
-        Codec.Create(up = up, down = down, ?settings = settings, ?rejectNullaryCases = rejectNullaryCases)
-
-    /// <summary>Generate an <code>IEventCodec</code> using the supplied <c>Newtonsoft.Json</c> <c>settings</c>.
-    /// Uses <c>up</c> and <c>down</c> and <c>mapCausation</c> functions to facilitate upconversion/downconversion and correlation/causationId mapping
-    ///   and/or surfacing metadata to the Programming Model by including it in the emitted <c>'Event</c>
+    /// <summary>Generate an <c>IEventCodec</c> that handles <c>ReadOnlyMemory&lt;byte&gt;</c> Event Bodies using the supplied <c>Newtonsoft.Json.JsonSerializerSettings</c> <c>options</c>.<br/>
+    /// Uses <c>up</c> and <c>down</c> functions to facilitate upconversion/downconversion/timestamping without eventId/correlation/causationId mapping
+    ///   and/or surfacing metadata to the programming model by including it in the emitted <c>'Event</c>
     /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name
-    /// <c>Contract</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.</summary>
+    /// <c>Contract</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies</summary>.
     static member Create<'Event, 'Contract, 'Meta when 'Contract :> TypeShape.UnionContract.IUnionContract>
         (   /// <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
             /// to the representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
-            up : FsCodec.ITimelineEvent<byte[]> * 'Contract -> 'Event,
+            up : FsCodec.ITimelineEvent<ReadOnlyMemory<byte>> * 'Contract -> 'Event,
             /// <summary>Maps a fresh <c>'Event</c> resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
             /// The function is also expected to derive
-            ///   a <c>meta</c> object that will be serialized with the same settings (if it's not <c>None</c>)
+            ///   a <c>meta</c> object that will be serialized with the same options (if it's not <c>None</c>)
             ///   and an Event Creation <c>timestamp</c>.</summary>
             down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
-            /// <summary>Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to <c>Options.Default</c></summary>
-            [<Optional; DefaultParameterValue(null)>] ?settings,
-            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them</summary>
+            /// <summary>Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c></summary>
+            [<Optional; DefaultParameterValue(null)>] ?options,
+            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
-        : FsCodec.IEventCodec<'Event, byte[], obj> =
+        : FsCodec.IEventCodec<'Event, ReadOnlyMemory<byte>, obj> =
+        FsCodec.Box.Core.Codec.Create(mkEncoder options, up, down, ?rejectNullaryCases = rejectNullaryCases)
 
-        let mapCausation (_context : obj, m : 'Meta option) = m, Guid.NewGuid(), null, null
-        Codec.Create(up = up, down = down, mapCausation = mapCausation, ?settings = settings, ?rejectNullaryCases = rejectNullaryCases)
-
-    /// <summary>Generate an <code>IEventCodec</code> using the supplied <c>Newtonsoft.Json</c> <c>settings</c>.
+    /// <summary>Generate an <c>IEventCodec</c> that handles <c>ReadOnlyMemory&lt;byte&gt;</c> Event Bodies using the supplied <c>Newtonsoft.Json.JsonSerializerSettings</c> <c>options</c>.<br/>
     /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name
     /// <c>'Union</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.</summary>
     static member Create<'Union when 'Union :> TypeShape.UnionContract.IUnionContract>
         (   /// <summary>Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c></summary>
-            [<Optional; DefaultParameterValue(null)>] ?settings,
-            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them</summary>
+            [<Optional; DefaultParameterValue(null)>] ?options,
+            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
-        : FsCodec.IEventCodec<'Union, byte[], obj> =
-
-        let up : FsCodec.ITimelineEvent<_> * 'Union -> 'Union = snd
-        let down (event : 'Union) = event, None, None
-        Codec.Create(up = up, down = down, ?settings = settings, ?rejectNullaryCases = rejectNullaryCases)
+        : FsCodec.IEventCodec<'Union, ReadOnlyMemory<byte>, obj> =
+        FsCodec.Box.Core.Codec.Create(mkEncoder options, ?rejectNullaryCases = rejectNullaryCases)

--- a/src/FsCodec.NewtonsoftJson/FsCodec.NewtonsoftJson.fsproj
+++ b/src/FsCodec.NewtonsoftJson/FsCodec.NewtonsoftJson.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
@@ -26,11 +26,10 @@
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="TypeShape" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../FsCodec/FsCodec.fsproj" />
+    <ProjectReference Include="../FsCodec.Box/FsCodec.Box.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/src/FsCodec.SystemTextJson/Codec.fs
+++ b/src/FsCodec.SystemTextJson/Codec.fs
@@ -61,7 +61,7 @@ type CodecJsonElement private () =
             /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, JsonElement, 'Context> =
-        Core.Codec.Create(mkEncoder options, up, down, ?rejectNullaryCases = rejectNullaryCases)
+        FsCodec.Box.Core.Codec.Create(mkEncoder options, up, down, ?rejectNullaryCases = rejectNullaryCases)
 
     /// <summary>Generate an <c>IEventCodec</c> that handles <c>JsonElement</c> Event Bodies using the supplied <c>System.Text.Json</c> <c>options</c>.
     /// Uses <c>up</c>, <c>down</c> and <c>mapCausation</c> functions to facilitate upconversion/downconversion and eventId/correlationId/causationId/timestamp mapping
@@ -84,7 +84,7 @@ type CodecJsonElement private () =
             /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, JsonElement, 'Context> =
-        Core.Codec.Create(mkEncoder options, up, down, mapCausation, ?rejectNullaryCases = rejectNullaryCases)
+        FsCodec.Box.Core.Codec.Create(mkEncoder options, up, down, mapCausation, ?rejectNullaryCases = rejectNullaryCases)
 
     /// <summary>Generate an <code>IEventCodec</code> that handles <c>JsonElement</c> Event Bodies using the supplied <c>System.Text.Json</c> <c>options</c>.
     /// Uses <c>up</c> and <c>down</c> functions to facilitate upconversion/downconversion/timestamping without eventId/correlation/causationId mapping
@@ -105,7 +105,7 @@ type CodecJsonElement private () =
             /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, JsonElement, obj> =
-        Core.Codec.Create(mkEncoder options, up, down, ?rejectNullaryCases = rejectNullaryCases)
+        FsCodec.Box.Core.Codec.Create(mkEncoder options, up, down, ?rejectNullaryCases = rejectNullaryCases)
 
     /// <summary>Generate an <code>IEventCodec</code> that handles <c>JsonElement</c> Event Bodies using the supplied <c>System.Text.Json</c> <c>options</c>.
     /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name
@@ -116,7 +116,7 @@ type CodecJsonElement private () =
             /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Union, JsonElement, obj> =
-        Core.Codec.Create(mkEncoder options, ?rejectNullaryCases = rejectNullaryCases)
+        FsCodec.Box.Core.Codec.Create(mkEncoder options, ?rejectNullaryCases = rejectNullaryCases)
 
 /// <summary>Provides Codecs that render to a <c>ReadOnlyMemory&lt;byte&gt;</c>, suitable for storage in Event Stores that handle Event Data and Metadata as opaque blobs.
 /// Requires that Contract types adhere to the conventions implied by using <c>TypeShape.UnionContract.UnionContractEncoder</c><br/>
@@ -148,7 +148,7 @@ type Codec private () =
             /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, ReadOnlyMemory<byte>, 'Context> =
-        Core.Codec.Create(mkEncoder options, up, down, ?rejectNullaryCases = rejectNullaryCases)
+        FsCodec.Box.Core.Codec.Create(mkEncoder options, up, down, ?rejectNullaryCases = rejectNullaryCases)
 
     /// <summary>Generate an <c>IEventCodec</c> that handles <c>ReadOnlyMemory&lt;byte&gt;</c> Event Bodies using the supplied <c>System.Text.Json</c> <c>options</c>.<br/>
     /// Uses <c>up</c>, <c>down</c> and <c>mapCausation</c> functions to facilitate upconversion/downconversion and eventId/correlationId/causationId/timestamp mapping
@@ -171,7 +171,7 @@ type Codec private () =
             /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, ReadOnlyMemory<byte>, 'Context> =
-        Core.Codec.Create(mkEncoder options, up, down, mapCausation, ?rejectNullaryCases = rejectNullaryCases)
+        FsCodec.Box.Core.Codec.Create(mkEncoder options, up, down, mapCausation, ?rejectNullaryCases = rejectNullaryCases)
 
     /// <summary>Generate an <c>IEventCodec</c> that handles <c>ReadOnlyMemory&lt;byte&gt;</c> Event Bodies using the supplied <c>System.Text.Json</c> <c>options</c>.<br/>
     /// Uses <c>up</c> and <c>down</c> functions to facilitate upconversion/downconversion/timestamping without eventId/correlation/causationId mapping
@@ -192,7 +192,7 @@ type Codec private () =
             /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, ReadOnlyMemory<byte>, obj> =
-        Core.Codec.Create(mkEncoder options, up, down, ?rejectNullaryCases = rejectNullaryCases)
+        FsCodec.Box.Core.Codec.Create(mkEncoder options, up, down, ?rejectNullaryCases = rejectNullaryCases)
 
     /// <summary>Generate an <c>IEventCodec</c> that handles <c>ReadOnlyMemory&lt;byte&gt;</c> Event Bodies using the supplied <c>System.Text.Json</c> <c>options</c>.<br/>
     /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name
@@ -203,4 +203,4 @@ type Codec private () =
             /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Union, ReadOnlyMemory<byte>, obj> =
-        Core.Codec.Create(mkEncoder options, ?rejectNullaryCases = rejectNullaryCases)
+        FsCodec.Box.Core.Codec.Create(mkEncoder options, ?rejectNullaryCases = rejectNullaryCases)

--- a/src/FsCodec.SystemTextJson/Codec.fs
+++ b/src/FsCodec.SystemTextJson/Codec.fs
@@ -1,8 +1,9 @@
 namespace FsCodec.SystemTextJson.Core
 
+open System
 open System.Text.Json
 
-/// System.Text.Json implementation of TypeShape.UnionContractEncoder's IEncoder that encodes to a `JsonElement`
+/// System.Text.Json implementation of TypeShape.UnionContractEncoder's IEncoder that encodes to a JsonElement
 type JsonElementEncoder(options : JsonSerializerOptions) =
     interface TypeShape.UnionContract.IEncoder<JsonElement> with
         member _.Empty = Unchecked.defaultof<_>
@@ -13,63 +14,59 @@ type JsonElementEncoder(options : JsonSerializerOptions) =
         member _.Decode<'T>(json : JsonElement) =
             JsonSerializer.Deserialize<'T>(json, options)
 
+/// System.Text.Json implementation of TypeShape.UnionContractEncoder's IEncoder that encodes to a ReadOnlyMemory<byte>
+type ReadOnlyMemoryEncoder(options : JsonSerializerOptions) =
+    interface TypeShape.UnionContract.IEncoder<ReadOnlyMemory<byte>> with
+        member _.Empty = ReadOnlyMemory.Empty
+
+        member _.Encode(value : 'T) =
+            JsonSerializer.SerializeToUtf8Bytes(value, options) |> ReadOnlyMemory
+
+        member _.Decode<'T>(json : ReadOnlyMemory<byte>) =
+            JsonSerializer.Deserialize<'T>(json.Span, options)
+
 namespace FsCodec.SystemTextJson
 
 open System
 open System.Runtime.InteropServices
 open System.Text.Json
 
-/// <summary>Provides Codecs that render to a JsonElement suitable for storage in Event Stores based using <c>System.Text.Json</c> and the conventions implied by using
-/// <c>TypeShape.UnionContract.UnionContractEncoder</c> - if you need full control and/or have have your own codecs, see <c>FsCodec.Codec.Create</c> instead
+/// <summary>Provides Codecs that render to a JsonElement suitable for storage in Event Stores that use <c>System.Text.Json</c> internally such as Equinox.CosmosStore v4 and later.
+/// Requires that Contract types adhere to the conventions implied by using <c>TypeShape.UnionContract.UnionContractEncoder</c><br/>
+/// If you need full control and/or have have your own codecs, see <c>FsCodec.Codec.Create</c> instead.<br/>
 /// See <a href="https://github.com/eiriktsarpalis/TypeShape/blob/master/tests/TypeShape.Tests/UnionContractTests.fs"></a> for example usage.</summary>
-type Codec private () =
+type CodecJsonElement private () =
 
-    /// <summary>Generate an <c>IEventCodec</c> using the supplied <c>System.Text.Json</c> <c>options</c>.<br/>
-    /// Uses <c>up</c> and <c>down</c> functions to facilitate upconversion/downconversion
-    ///   and/or surfacing metadata to the Programming Model by including it in the emitted <c>'Event</c><br/>
-    /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name
+    static let DefaultEncoder = lazy (Core.JsonElementEncoder Options.Default :> TypeShape.UnionContract.IEncoder<JsonElement>)
+
+    static let mkEncoder : JsonSerializerOptions option -> TypeShape.UnionContract.IEncoder<JsonElement> = function
+        | None -> DefaultEncoder.Value
+        | Some opts -> Core.JsonElementEncoder opts :> _
+
+    /// <summary>Generate an <code>IEventCodec</code> that handles <c>JsonElement</c> Event Bodies using the supplied <c>System.Text.Json</c> <c>options</c>.
+    /// Uses <c>up</c>, <c>down</c> functions to handle upconversion/downconversion and eventId/correlationId/causationId mapping
+    ///   and/or surfacing metadata to the programming model by including it in the emitted <c>'Event</c><br/>
+    /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name;
     /// <c>Contract</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.</summary>
     static member Create<'Event, 'Contract, 'Meta, 'Context when 'Contract :> TypeShape.UnionContract.IUnionContract>
         (   /// <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
             /// to the <c>'Event</c> representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
             up : FsCodec.ITimelineEvent<JsonElement> * 'Contract -> 'Event,
             /// <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c><br/>
-            /// The function is also expected to derive
-            ///   a <c>meta</c> object that will be serialized with the same options (if it's not <c>None</c>)
-            ///   and an Event Creation <c>timestamp</c><summary>.
+            /// The function is also expected to derive an optional <c>meta</c> object that will be serialized with the same <c>encoder</c>,
+            /// and <c>eventId</c>, <c>correlationId</c>, <c>causationId</c> and an Event Creation<c>timestamp</c></summary>.
             down : 'Context option * 'Event -> 'Contract * 'Meta option * Guid * string * string * DateTimeOffset option,
             /// <summary>Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c></summary>
             [<Optional; DefaultParameterValue(null)>] ?options,
-            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them</summary>
+            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, JsonElement, 'Context> =
+        Core.Codec.Create(mkEncoder options, up, down, ?rejectNullaryCases = rejectNullaryCases)
 
-        let options = match options with Some x -> x | None -> Options.Default
-        let elementEncoder : TypeShape.UnionContract.IEncoder<_> = Core.JsonElementEncoder(options) :> _
-        let dataCodec =
-            TypeShape.UnionContract.UnionContractEncoder.Create<'Contract, JsonElement>(
-                elementEncoder,
-                // Round-tripping cases like null and/or empty strings etc involves edge cases that stores,
-                // FsCodec.NewtonsoftJson.Codec, Interop.fs and InteropTests.fs do not cover, so we disable this
-                requireRecordFields = true,
-                allowNullaryCases = not (defaultArg rejectNullaryCases false))
-
-        { new FsCodec.IEventCodec<'Event, JsonElement, 'Context> with
-            member _.Encode(context, event) =
-                let (c, meta : 'Meta option, eventId, correlationId, causationId, timestamp : DateTimeOffset option) = down (context, event)
-                let enc = dataCodec.Encode c
-                let meta' = match meta with Some x -> elementEncoder.Encode<'Meta> x | None -> Unchecked.defaultof<_>
-                FsCodec.Core.EventData.Create(enc.CaseName, enc.Payload, meta', eventId, correlationId, causationId, ?timestamp = timestamp)
-
-            member _.TryDecode encoded =
-                match dataCodec.TryDecode { CaseName = encoded.EventType; Payload = encoded.Data } with
-                | None -> None
-                | Some contract -> up (encoded, contract) |> Some }
-
-    /// <summary>Generate an <code>IEventCodec</code> using the supplied <c>System.Text.Json</c> <c>options</c>.<br/>
-    /// Uses <c>up</c> and <c>down</c> and <c>mapCausation</c> functions to facilitate upconversion/downconversion and correlation/causationId mapping
-    ///   and/or surfacing metadata to the Programming Model by including it in the emitted <c>'Event</c>
-    /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name
+    /// <summary>Generate an <c>IEventCodec</c> that handles <c>JsonElement</c> Event Bodies using the supplied <c>System.Text.Json</c> <c>options</c>.
+    /// Uses <c>up</c>, <c>down</c> and <c>mapCausation</c> functions to facilitate upconversion/downconversion and eventId/correlationId/causationId/timestamp mapping
+    ///   and/or surfacing metadata to the programming model by including it in the emitted <c>'Event</c>
+    /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name;
     /// <c>Contract</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.</summary>
     static member Create<'Event, 'Contract, 'Meta, 'Context when 'Contract :> TypeShape.UnionContract.IUnionContract>
         (   /// <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
@@ -80,23 +77,18 @@ type Codec private () =
             ///   a <c>meta</c> object that will be serialized with the same options (if it's not <c>None</c>)
             ///   and an Event Creation <c>timestamp</c>.</summary>
             down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
-            /// <summary>Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>correlationId</c> and c) the correlationId</summary>
+            /// <summary>Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>eventId</c> c) the <c>correlationId</c> and d) the <c>causationId</c></summary>
             mapCausation : 'Context option * 'Meta option -> 'Meta option * Guid * string * string,
-            /// <summary>Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c></summary>
+            /// <summary>Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c>.</summary>
             [<Optional; DefaultParameterValue(null)>] ?options,
-            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them</summary>
+            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, JsonElement, 'Context> =
+        Core.Codec.Create(mkEncoder options, up, down, mapCausation, ?rejectNullaryCases = rejectNullaryCases)
 
-        let down (context, union) =
-            let c, m, t = down union
-            let m', eventId, correlationId, causationId = mapCausation (context, m)
-            c, m', eventId, correlationId, causationId, t
-        Codec.Create(up = up, down = down, ?options = options, ?rejectNullaryCases = rejectNullaryCases)
-
-    /// <summary>Generate an <code>IEventCodec</code> using the supplied <c>System.Text.Json</c> <c>options</c>.
-    /// Uses <c>up</c> and <c>down</c> and <c>mapCausation</c> functions to facilitate upconversion/downconversion and correlation/causationId mapping
-    ///   and/or surfacing metadata to the Programming Model by including it in the emitted <c>'Event</c>
+    /// <summary>Generate an <code>IEventCodec</code> that handles <c>JsonElement</c> Event Bodies using the supplied <c>System.Text.Json</c> <c>options</c>.
+    /// Uses <c>up</c> and <c>down</c> functions to facilitate upconversion/downconversion/timestamping without eventId/correlation/causationId mapping
+    ///   and/or surfacing metadata to the programming model by including it in the emitted <c>'Event</c>
     /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name
     /// <c>Contract</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies</summary>.
     static member Create<'Event, 'Contract, 'Meta when 'Contract :> TypeShape.UnionContract.IUnionContract>
@@ -108,25 +100,107 @@ type Codec private () =
             ///   a <c>meta</c> object that will be serialized with the same options (if it's not <c>None</c>)
             ///   and an Event Creation <c>timestamp</c>.</summary>
             down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
-            /// <summary>Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c></summary>
+            /// <summary>Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c>.</summary>
             [<Optional; DefaultParameterValue(null)>] ?options,
-            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them</summary>
+            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, JsonElement, obj> =
+        Core.Codec.Create(mkEncoder options, up, down, ?rejectNullaryCases = rejectNullaryCases)
 
-        let mapCausation (_context : obj, m : 'Meta option) = m, Guid.NewGuid(), null, null
-        Codec.Create(up = up, down = down, mapCausation = mapCausation, ?options = options, ?rejectNullaryCases = rejectNullaryCases)
-
-    /// <summary>Generate an <code>IEventCodec</code> using the supplied <c>System.Text.Json</c> <c>options</c>.
+    /// <summary>Generate an <code>IEventCodec</code> that handles <c>JsonElement</c> Event Bodies using the supplied <c>System.Text.Json</c> <c>options</c>.
     /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name
     /// <c>'Union</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.</summary>
     static member Create<'Union when 'Union :> TypeShape.UnionContract.IUnionContract>
-        (   /// <summary>Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c></summary>
+        (   /// <summary>Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c>.</summary>
             [<Optional; DefaultParameterValue(null)>] ?options,
-            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them</summary>
+            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Union, JsonElement, obj> =
+        Core.Codec.Create(mkEncoder options, ?rejectNullaryCases = rejectNullaryCases)
 
-        let up : FsCodec.ITimelineEvent<_> * 'Union -> 'Union = snd
-        let down (event : 'Union) = event, None, None
-        Codec.Create(up = up, down = down, ?options = options, ?rejectNullaryCases = rejectNullaryCases)
+/// <summary>Provides Codecs that render to a <c>ReadOnlyMemory&lt;byte&gt;</c>, suitable for storage in Event Stores that handle Event Data and Metadata as opaque blobs.
+/// Requires that Contract types adhere to the conventions implied by using <c>TypeShape.UnionContract.UnionContractEncoder</c><br/>
+/// If you need full control and/or have have your own codecs, see <c>FsCodec.Codec.Create</c> instead.<br/>
+/// See <a href="https://github.com/eiriktsarpalis/TypeShape/blob/master/tests/TypeShape.Tests/UnionContractTests.fs"></a> for example usage.</summary>
+type Codec private () =
+
+    static let DefaultEncoder : Lazy<TypeShape.UnionContract.IEncoder<ReadOnlyMemory<byte>>> = lazy (Core.ReadOnlyMemoryEncoder Options.Default :> _)
+
+    static let mkEncoder : JsonSerializerOptions option -> TypeShape.UnionContract.IEncoder<ReadOnlyMemory<byte>> = function
+        | None -> DefaultEncoder.Value
+        | Some opts -> Core.ReadOnlyMemoryEncoder opts :> _
+
+    /// <summary>Generate an <c>IEventCodec</c> that handles <c>ReadOnlyMemory&lt;byte&gt;</c> Event Bodies using the supplied <c>System.Text.Json</c> <c>options</c>.<br/>
+    /// Uses <c>up</c>, <c>down</c> functions to handle upconversion/downconversion and eventId/correlationId/causationId mapping
+    ///   and/or surfacing metadata to the programming model by including it in the emitted <c>'Event</c><br/>
+    /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name;
+    /// <c>Contract</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.</summary>
+    static member Create<'Event, 'Contract, 'Meta, 'Context when 'Contract :> TypeShape.UnionContract.IUnionContract>
+        (   /// <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
+            /// to the <c>'Event</c> representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
+            up : FsCodec.ITimelineEvent<ReadOnlyMemory<byte>> * 'Contract -> 'Event,
+            /// <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c><br/>
+            /// The function is also expected to derive an optional <c>meta</c> object that will be serialized with the same <c>encoder</c>,
+            /// and <c>eventId</c>, <c>correlationId</c>, <c>causationId</c> and an Event Creation<c>timestamp</c></summary>.
+            down : 'Context option * 'Event -> 'Contract * 'Meta option * Guid * string * string * DateTimeOffset option,
+            /// <summary>Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c></summary>
+            [<Optional; DefaultParameterValue(null)>] ?options,
+            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
+            [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
+        : FsCodec.IEventCodec<'Event, ReadOnlyMemory<byte>, 'Context> =
+        Core.Codec.Create(mkEncoder options, up, down, ?rejectNullaryCases = rejectNullaryCases)
+
+    /// <summary>Generate an <c>IEventCodec</c> that handles <c>ReadOnlyMemory&lt;byte&gt;</c> Event Bodies using the supplied <c>System.Text.Json</c> <c>options</c>.<br/>
+    /// Uses <c>up</c>, <c>down</c> and <c>mapCausation</c> functions to facilitate upconversion/downconversion and eventId/correlationId/causationId/timestamp mapping
+    ///   and/or surfacing metadata to the programming model by including it in the emitted <c>'Event</c>
+    /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name;
+    /// <c>Contract</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.</summary>
+    static member Create<'Event, 'Contract, 'Meta, 'Context when 'Contract :> TypeShape.UnionContract.IUnionContract>
+        (   /// <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
+            /// to the representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
+            up : FsCodec.ITimelineEvent<ReadOnlyMemory<byte>> * 'Contract -> 'Event,
+            /// <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
+            /// The function is also expected to derive
+            ///   a <c>meta</c> object that will be serialized with the same options (if it's not <c>None</c>)
+            ///   and an Event Creation <c>timestamp</c>.</summary>
+            down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
+            /// <summary>Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>eventId</c> c) the <c>correlationId</c> and d) the <c>causationId</c></summary>
+            mapCausation : 'Context option * 'Meta option -> 'Meta option * Guid * string * string,
+            /// <summary>Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c>.</summary>
+            [<Optional; DefaultParameterValue(null)>] ?options,
+            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
+            [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
+        : FsCodec.IEventCodec<'Event, ReadOnlyMemory<byte>, 'Context> =
+        Core.Codec.Create(mkEncoder options, up, down, mapCausation, ?rejectNullaryCases = rejectNullaryCases)
+
+    /// <summary>Generate an <c>IEventCodec</c> that handles <c>ReadOnlyMemory&lt;byte&gt;</c> Event Bodies using the supplied <c>System.Text.Json</c> <c>options</c>.<br/>
+    /// Uses <c>up</c> and <c>down</c> functions to facilitate upconversion/downconversion/timestamping without eventId/correlation/causationId mapping
+    ///   and/or surfacing metadata to the programming model by including it in the emitted <c>'Event</c>
+    /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name
+    /// <c>Contract</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies</summary>.
+    static member Create<'Event, 'Contract, 'Meta when 'Contract :> TypeShape.UnionContract.IUnionContract>
+        (   /// <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
+            /// to the representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
+            up : FsCodec.ITimelineEvent<ReadOnlyMemory<byte>> * 'Contract -> 'Event,
+            /// <summary>Maps a fresh <c>'Event</c> resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
+            /// The function is also expected to derive
+            ///   a <c>meta</c> object that will be serialized with the same options (if it's not <c>None</c>)
+            ///   and an Event Creation <c>timestamp</c>.</summary>
+            down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
+            /// <summary>Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c>.</summary>
+            [<Optional; DefaultParameterValue(null)>] ?options,
+            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
+            [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
+        : FsCodec.IEventCodec<'Event, ReadOnlyMemory<byte>, obj> =
+        Core.Codec.Create(mkEncoder options, up, down, ?rejectNullaryCases = rejectNullaryCases)
+
+    /// <summary>Generate an <c>IEventCodec</c> that handles <c>ReadOnlyMemory&lt;byte&gt;</c> Event Bodies using the supplied <c>System.Text.Json</c> <c>options</c>.<br/>
+    /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name
+    /// <c>'Union</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.</summary>
+    static member Create<'Union when 'Union :> TypeShape.UnionContract.IUnionContract>
+        (   /// <summary>Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c>.</summary>
+            [<Optional; DefaultParameterValue(null)>] ?options,
+            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
+            [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
+        : FsCodec.IEventCodec<'Union, ReadOnlyMemory<byte>, obj> =
+        Core.Codec.Create(mkEncoder options, ?rejectNullaryCases = rejectNullaryCases)

--- a/src/FsCodec.SystemTextJson/CoreCodec.fs
+++ b/src/FsCodec.SystemTextJson/CoreCodec.fs
@@ -1,0 +1,111 @@
+namespace FsCodec.SystemTextJson.Core
+
+open System
+open System.Text.Json
+open System.Runtime.InteropServices
+
+/// <summary>Low-level Codec Generator that encodes to a Generic Event <c>'Body</c> Type.
+/// Requires that Contract types adhere to the conventions implied by using <c>TypeShape.UnionContract.UnionContractEncoder</c><br/>
+/// If you need full control and/or have have your own codecs, see <c>FsCodec.Codec.Create</c> instead.<br/>
+/// See non-<c>Core</c> namespace for application level encoders.</summary>
+type Codec private () =
+
+    /// <summary>Generate an <c>IEventCodec</c> using the supplied <c>encoder</c>.<br/>
+    /// Uses <c>up</c>, <c>down</c> functions to handle upconversion/downconversion and eventId/correlationId/causationId mapping
+    ///   and/or surfacing metadata to the programming model by including it in the emitted <c>'Event</c><br/>
+    /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name;
+    /// <c>Contract</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.</summary>
+    static member Create<'Event, 'Contract, 'Meta, 'Body, 'Context when 'Contract :> TypeShape.UnionContract.IUnionContract>
+        (   encoder,
+            /// <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
+            /// to the <c>'Event</c> representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
+            up : FsCodec.ITimelineEvent<'Body> * 'Contract -> 'Event,
+            /// <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c><br/>
+            /// The function is also expected to derive an optional <c>meta</c> object that will be serialized with the same <c>encoder</c>,
+            /// and <c>eventId</c>, <c>correlationId</c>, <c>causationId</c> and an Event Creation<c>timestamp</c></summary>.
+            down : 'Context option * 'Event -> 'Contract * 'Meta option * Guid * string * string * DateTimeOffset option,
+            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
+            [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
+        : FsCodec.IEventCodec<'Event, 'Body, 'Context> =
+
+        let dataCodec =
+            TypeShape.UnionContract.UnionContractEncoder.Create<'Contract, 'Body>(
+                encoder,
+                // Round-tripping cases like null and/or empty strings etc involves edge cases that stores,
+                // FsCodec.NewtonsoftJson.Codec, Interop.fs and InteropTests.fs do not cover, so we disable this
+                requireRecordFields = true,
+                allowNullaryCases = not (defaultArg rejectNullaryCases false))
+
+        { new FsCodec.IEventCodec<'Event, 'Body, 'Context> with
+            member _.Encode(context, event) =
+                let (c, meta : 'Meta option, eventId, correlationId, causationId, timestamp : DateTimeOffset option) = down (context, event)
+                let enc = dataCodec.Encode c
+                let meta' = match meta with Some x -> encoder.Encode<'Meta> x | None -> Unchecked.defaultof<_>
+                FsCodec.Core.EventData.Create(enc.CaseName, enc.Payload, meta', eventId, correlationId, causationId, ?timestamp = timestamp)
+
+            member _.TryDecode encoded =
+                match dataCodec.TryDecode { CaseName = encoded.EventType; Payload = encoded.Data } with
+                | None -> None
+                | Some contract -> up (encoded, contract) |> Some }
+
+    /// <summary>Generate an <c>IEventCodec</c> using the supplied <c>encoder</c>.<br/>
+    /// Uses <c>up</c>, <c>down</c> and <c>mapCausation</c> functions to facilitate upconversion/downconversion and eventId/correlationId/causationId/timestamp mapping
+    ///   and/or surfacing metadata to the programming model by including it in the emitted <c>'Event</c>
+    /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name;
+    /// <c>Contract</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.</summary>
+    static member Create<'Event, 'Contract, 'Meta, 'Body, 'Context when 'Contract :> TypeShape.UnionContract.IUnionContract>
+        (   encoder,
+            /// <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
+            /// to the representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
+            up : FsCodec.ITimelineEvent<'Body> * 'Contract -> 'Event,
+            /// <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
+            /// The function is also expected to derive
+            ///   a <c>meta</c> object that will be serialized with the same options (if it's not <c>None</c>)
+            ///   and an Event Creation <c>timestamp</c>.</summary>
+            down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
+            /// <summary>Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>eventId</c> c) the <c>correlationId</c> and d) the <c>causationId</c></summary>
+            mapCausation : 'Context option * 'Meta option -> 'Meta option * Guid * string * string,
+            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
+            [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
+        : FsCodec.IEventCodec<'Event, 'Body, 'Context> =
+
+        let down (context, union) =
+            let c, m, t = down union
+            let m', eventId, correlationId, causationId = mapCausation (context, m)
+            c, m', eventId, correlationId, causationId, t
+        Codec.Create(encoder, up = up, down = down, ?rejectNullaryCases = rejectNullaryCases)
+
+    /// <summary>Generate an <code>IEventCodec</code> using the supplied <c>encoder</c>.<br/>
+    /// Uses <c>up</c> and <c>down</c> functions to facilitate upconversion/downconversion/timestamping without eventId/correlation/causationId mapping
+    ///   and/or surfacing metadata to the programming model by including it in the emitted <c>'Event</c>
+    /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name
+    /// <c>Contract</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies</summary>.
+    static member Create<'Event, 'Contract, 'Meta, 'Body when 'Contract :> TypeShape.UnionContract.IUnionContract>
+        (   encoder,
+            /// <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
+            /// to the representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
+            up : FsCodec.ITimelineEvent<'Body> * 'Contract -> 'Event,
+            /// <summary>Maps a fresh <c>'Event</c> resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
+            /// The function is also expected to derive
+            ///   a <c>meta</c> object that will be serialized with the same options (if it's not <c>None</c>)
+            ///   and an Event Creation <c>timestamp</c>.</summary>
+            down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
+            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
+            [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
+        : FsCodec.IEventCodec<'Event, 'Body, obj> =
+
+        let mapCausation (_context : obj, m : 'Meta option) = m, Guid.NewGuid(), null, null
+        Codec.Create(encoder, up = up, down = down, mapCausation = mapCausation, ?rejectNullaryCases = rejectNullaryCases)
+
+    /// <summary>Generate an <code>IEventCodec</code> using the supplied <c>encoder</c>.<br/>
+    /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name
+    /// <c>'Union</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.</summary>
+    static member Create<'Body, 'Union when 'Union :> TypeShape.UnionContract.IUnionContract>
+        (   encoder : TypeShape.UnionContract.IEncoder<'Body>,
+            /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
+            [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
+        : FsCodec.IEventCodec<'Union, 'Body, obj> =
+
+        let up : FsCodec.ITimelineEvent<'Body> * 'Union -> 'Union = snd
+        let down (event : 'Union) = event, None, None
+        Codec.Create(encoder, up = up, down = down, ?rejectNullaryCases = rejectNullaryCases)

--- a/src/FsCodec.SystemTextJson/FsCodec.SystemTextJson.fsproj
+++ b/src/FsCodec.SystemTextJson/FsCodec.SystemTextJson.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="TypeSafeEnumConverter.fs" />
     <Compile Include="UnionOrTypeSafeEnumConverterFactory.fs" />
     <Compile Include="Options.fs" />
+    <Compile Include="CoreCodec.fs" />
     <Compile Include="Codec.fs" />
     <Compile Include="Serdes.fs" />
     <Compile Include="Interop.fs" />

--- a/src/FsCodec.SystemTextJson/FsCodec.SystemTextJson.fsproj
+++ b/src/FsCodec.SystemTextJson/FsCodec.SystemTextJson.fsproj
@@ -12,7 +12,6 @@
     <Compile Include="TypeSafeEnumConverter.fs" />
     <Compile Include="UnionOrTypeSafeEnumConverterFactory.fs" />
     <Compile Include="Options.fs" />
-    <Compile Include="CoreCodec.fs" />
     <Compile Include="Codec.fs" />
     <Compile Include="Serdes.fs" />
     <Compile Include="Interop.fs" />
@@ -25,11 +24,10 @@
     <PackageReference Include="FSharp.Core" Version="4.5.4" />
 
     <PackageReference Include="System.Text.Json" Version="6.0.1" />
-    <PackageReference Include="TypeShape" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../FsCodec/FsCodec.fsproj" />
+    <ProjectReference Include="../FsCodec.Box/FsCodec.Box.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/src/FsCodec.SystemTextJson/Interop.fs
+++ b/src/FsCodec.SystemTextJson/Interop.fs
@@ -1,50 +1,12 @@
-namespace FsCodec.SystemTextJson
+namespace FsCodec.SystemTextJson.Interop
 
+open FsCodec.SystemTextJson
 open System.Runtime.CompilerServices
 open System
 open System.Text.Json
 
 [<Extension>]
 type InteropExtensions =
-    static member private Adapt<'From, 'To, 'Event, 'Context>
-        (   native : FsCodec.IEventCodec<'Event, 'From, 'Context>,
-            up : 'From -> 'To,
-            down : 'To -> 'From) : FsCodec.IEventCodec<'Event, 'To, 'Context> =
-
-        { new FsCodec.IEventCodec<'Event, 'To, 'Context> with
-            member _.Encode(context, event) =
-                let encoded = native.Encode(context, event)
-                { new FsCodec.IEventData<_> with
-                    member _.EventType = encoded.EventType
-                    member _.Data = up encoded.Data
-                    member _.Meta = up encoded.Meta
-                    member _.EventId = encoded.EventId
-                    member _.CorrelationId = encoded.CorrelationId
-                    member _.CausationId = encoded.CausationId
-                    member _.Timestamp = encoded.Timestamp }
-
-            member _.TryDecode encoded =
-                let mapped =
-                    { new FsCodec.ITimelineEvent<_> with
-                        member _.Index = encoded.Index
-                        member _.IsUnfold = encoded.IsUnfold
-                        member _.Context = encoded.Context
-                        member _.EventType = encoded.EventType
-                        member _.Data = down encoded.Data
-                        member _.Meta = down encoded.Meta
-                        member _.EventId = encoded.EventId
-                        member _.CorrelationId = encoded.CorrelationId
-                        member _.CausationId = encoded.CausationId
-                        member _.Timestamp = encoded.Timestamp }
-                native.TryDecode mapped }
-
-    static member private JsonElementToUtf8Bytes(x : JsonElement) =
-        // Avoid introduction of HTML escaping for things like quotes etc (Options.Default uses Options.Create(), which defaults to unsafeRelaxedJsonEscaping=true)
-        JsonSerializer.SerializeToUtf8Bytes(x, options = Options.Default)
-
-    (* ========================
-       Adapt an IEventCodec that uses JsonElement Event Bodies to instead use ReadOnlyMemory<byte>
-       Ideally not necessary; using Codec instead of CodecJsonElement in the first instance is preferable where possible *)
 
     static member private Utf8ToJsonElement(x : ReadOnlyMemory<byte>) : JsonElement =
         if x.IsEmpty then JsonElement()
@@ -52,50 +14,19 @@ type InteropExtensions =
 
     static member private JsonElementToUtf8(x : JsonElement) : ReadOnlyMemory<byte> =
         if x.ValueKind = JsonValueKind.Undefined then ReadOnlyMemory.Empty
-        else InteropExtensions.JsonElementToUtf8Bytes x |> ReadOnlyMemory
+        // Avoid introduction of HTML escaping for things like quotes etc (Options.Default uses Options.Create(), which defaults to unsafeRelaxedJsonEscaping=true)
+        else JsonSerializer.SerializeToUtf8Bytes(x, options = Options.Default) |> ReadOnlyMemory
 
     /// Adapts an IEventCodec that's rendering to <c>JsonElement</c> Event Bodies to handle <c>ReadOnlyMemory<byte></c> bodies instead.<br/>
     /// NOTE where possible, it's better to use <c>Codec</c> in preference to <c>CodecJsonElement</c> to encode directly in order to avoid this mapping process.
     [<Extension>]
     static member ToUtf8Codec<'Event, 'Context>(native : FsCodec.IEventCodec<'Event, JsonElement, 'Context>)
         : FsCodec.IEventCodec<'Event, ReadOnlyMemory<byte>, 'Context> =
-        InteropExtensions.Adapt(native, InteropExtensions.JsonElementToUtf8, InteropExtensions.Utf8ToJsonElement)
+        FsCodec.Interop.InteropExtensions.Adapt(native, InteropExtensions.JsonElementToUtf8, InteropExtensions.Utf8ToJsonElement)
 
-    (* ========================
-       Adapt an IEventCodec that handles ReadOnlyMemory<byte> Event Bodies to instead use byte[]
-       Ideally not used as it makes pooling problematic; only provided for interop/porting scaffolding wrt Equinox V3 and EventStore.Client etc *)
-
-    static member private BytesToReadOnlyMemory(x : byte[]) : ReadOnlyMemory<byte> =
-        if x = null then ReadOnlyMemory.Empty
-        else ReadOnlyMemory x
-    static member private ReadOnlyMemoryToBytes(x : ReadOnlyMemory<byte>) : byte[] =
-        if x.IsEmpty then null
-        else x.ToArray()
-
+    /// Adapts an IEventCodec that's rendering to <c>ReadOnlyMemory<byte></c> Event Bodies to handle <c>JsonElement</c> bodies instead.<br/>
+    /// NOTE where possible, it's better to use <c>CodecJsonElement</c> in preference to <c>Codec/c> to encode directly in order to avoid this mapping process.
     [<Extension>]
-    static member ToByteArrayCodec<'Event, 'Context>(native : FsCodec.IEventCodec<'Event, ReadOnlyMemory<byte>, 'Context>)
-        : FsCodec.IEventCodec<'Event, byte[], 'Context> =
-        InteropExtensions.Adapt(native, InteropExtensions.ReadOnlyMemoryToBytes, InteropExtensions.BytesToReadOnlyMemory)
-
-    (* ========================
-       Shim layer to allow interop with FsCodec.NewtonsoftJson, which natively renders to byte[] *)
-
-    static member private BytesToJsonElement(x : byte[]) : JsonElement =
-        if x = null then JsonElement()
-        else JsonSerializer.Deserialize<JsonElement>(ReadOnlySpan.op_Implicit x)
-
-    static member private JsonElementToBytes(x : JsonElement) : byte[] =
-        if x.ValueKind = JsonValueKind.Undefined then null
-        else InteropExtensions.JsonElementToUtf8Bytes x
-
-    /// Facilitates interop with FsCodec.NewtonsoftJson, which renders natively as byte[]
-    [<Extension>]
-    static member ToJsonElementCodec<'Event, 'Context>(native : FsCodec.IEventCodec<'Event, byte[], 'Context>)
+    static member ToJsonElementCodec<'Event, 'Context>(native : FsCodec.IEventCodec<'Event, ReadOnlyMemory<byte>, 'Context>)
         : FsCodec.IEventCodec<'Event, JsonElement, 'Context> =
-        InteropExtensions.Adapt(native, InteropExtensions.BytesToJsonElement, InteropExtensions.JsonElementToBytes)
-
-    /// Adapts an IEventCodec that's rendering to <c>byte[]</c> Event Bodies to handle <c>ReadOnlyMemory<byte></c> bodies instead.<br/>
-    [<Extension>]
-    static member ToUtf8Codec<'Event, 'Context>(native : FsCodec.IEventCodec<'Event, byte[], 'Context>)
-        : FsCodec.IEventCodec<'Event, ReadOnlyMemory<byte>, 'Context> =
-        InteropExtensions.Adapt(native, InteropExtensions.BytesToReadOnlyMemory, InteropExtensions.ReadOnlyMemoryToBytes)
+        FsCodec.Interop.InteropExtensions.Adapt(native, InteropExtensions.Utf8ToJsonElement, InteropExtensions.JsonElementToUtf8)

--- a/src/FsCodec.SystemTextJson/Interop.fs
+++ b/src/FsCodec.SystemTextJson/Interop.fs
@@ -1,6 +1,7 @@
 namespace FsCodec.SystemTextJson
 
 open System.Runtime.CompilerServices
+open System
 open System.Text.Json
 
 [<Extension>]
@@ -37,20 +38,64 @@ type InteropExtensions =
                         member _.Timestamp = encoded.Timestamp }
                 native.TryDecode mapped }
 
-    static member private MapFrom(x : byte[]) : JsonElement =
-        if x = null then JsonElement()
-        else JsonSerializer.Deserialize(System.ReadOnlySpan.op_Implicit x)
-    static member private MapTo(x: JsonElement) : byte[] =
-        if x.ValueKind = JsonValueKind.Undefined then null
+    static member private JsonElementToUtf8Bytes(x : JsonElement) =
         // Avoid introduction of HTML escaping for things like quotes etc (Options.Default uses Options.Create(), which defaults to unsafeRelaxedJsonEscaping=true)
-        else JsonSerializer.SerializeToUtf8Bytes(x, options = Options.Default)
+        JsonSerializer.SerializeToUtf8Bytes(x, options = Options.Default)
+
+    (* ========================
+       Adapt an IEventCodec that uses JsonElement Event Bodies to instead use ReadOnlyMemory<byte>
+       Ideally not necessary; using Codec instead of CodecJsonElement in the first instance is preferable where possible *)
+
+    static member private Utf8ToJsonElement(x : ReadOnlyMemory<byte>) : JsonElement =
+        if x.IsEmpty then JsonElement()
+        else JsonSerializer.Deserialize<JsonElement>(x.Span)
+
+    static member private JsonElementToUtf8(x : JsonElement) : ReadOnlyMemory<byte> =
+        if x.ValueKind = JsonValueKind.Undefined then ReadOnlyMemory.Empty
+        else InteropExtensions.JsonElementToUtf8Bytes x |> ReadOnlyMemory
+
+    /// Adapts an IEventCodec that's rendering to <c>JsonElement</c> Event Bodies to handle <c>ReadOnlyMemory<byte></c> bodies instead.<br/>
+    /// NOTE where possible, it's better to use <c>Codec</c> in preference to <c>CodecJsonElement</c> to encode directly in order to avoid this mapping process.
+    [<Extension>]
+    static member ToUtf8Codec<'Event, 'Context>(native : FsCodec.IEventCodec<'Event, JsonElement, 'Context>)
+        : FsCodec.IEventCodec<'Event, ReadOnlyMemory<byte>, 'Context> =
+        InteropExtensions.Adapt(native, InteropExtensions.JsonElementToUtf8, InteropExtensions.Utf8ToJsonElement)
+
+    (* ========================
+       Adapt an IEventCodec that handles ReadOnlyMemory<byte> Event Bodies to instead use byte[]
+       Ideally not used as it makes pooling problematic; only provided for interop/porting scaffolding wrt Equinox V3 and EventStore.Client etc *)
+
+    static member private BytesToReadOnlyMemory(x : byte[]) : ReadOnlyMemory<byte> =
+        if x = null then ReadOnlyMemory.Empty
+        else ReadOnlyMemory x
+    static member private ReadOnlyMemoryToBytes(x : ReadOnlyMemory<byte>) : byte[] =
+        if x.IsEmpty then null
+        else x.ToArray()
 
     [<Extension>]
-    static member ToByteArrayCodec<'Event, 'Context>(native : FsCodec.IEventCodec<'Event, JsonElement, 'Context>)
+    static member ToByteArrayCodec<'Event, 'Context>(native : FsCodec.IEventCodec<'Event, ReadOnlyMemory<byte>, 'Context>)
         : FsCodec.IEventCodec<'Event, byte[], 'Context> =
-        InteropExtensions.Adapt(native, InteropExtensions.MapTo, InteropExtensions.MapFrom)
+        InteropExtensions.Adapt(native, InteropExtensions.ReadOnlyMemoryToBytes, InteropExtensions.BytesToReadOnlyMemory)
 
+    (* ========================
+       Shim layer to allow interop with FsCodec.NewtonsoftJson, which natively renders to byte[] *)
+
+    static member private BytesToJsonElement(x : byte[]) : JsonElement =
+        if x = null then JsonElement()
+        else JsonSerializer.Deserialize<JsonElement>(ReadOnlySpan.op_Implicit x)
+
+    static member private JsonElementToBytes(x : JsonElement) : byte[] =
+        if x.ValueKind = JsonValueKind.Undefined then null
+        else InteropExtensions.JsonElementToUtf8Bytes x
+
+    /// Facilitates interop with FsCodec.NewtonsoftJson, which renders natively as byte[]
     [<Extension>]
     static member ToJsonElementCodec<'Event, 'Context>(native : FsCodec.IEventCodec<'Event, byte[], 'Context>)
         : FsCodec.IEventCodec<'Event, JsonElement, 'Context> =
-        InteropExtensions.Adapt(native, InteropExtensions.MapFrom, InteropExtensions.MapTo)
+        InteropExtensions.Adapt(native, InteropExtensions.BytesToJsonElement, InteropExtensions.JsonElementToBytes)
+
+    /// Adapts an IEventCodec that's rendering to <c>byte[]</c> Event Bodies to handle <c>ReadOnlyMemory<byte></c> bodies instead.<br/>
+    [<Extension>]
+    static member ToUtf8Codec<'Event, 'Context>(native : FsCodec.IEventCodec<'Event, byte[], 'Context>)
+        : FsCodec.IEventCodec<'Event, ReadOnlyMemory<byte>, 'Context> =
+        InteropExtensions.Adapt(native, InteropExtensions.BytesToReadOnlyMemory, InteropExtensions.ReadOnlyMemoryToBytes)

--- a/src/FsCodec/FsCodec.fs
+++ b/src/FsCodec/FsCodec.fs
@@ -4,7 +4,7 @@ namespace FsCodec
 type IEventData<'Format> =
     /// The Event Type, used to drive deserialization
     abstract member EventType : string
-    /// Event body, as UTF-8 encoded JSON, protobuf etc, ready to be injected into the Store
+    /// Event body, as UTF-8 encoded JSON / protobuf etc, ready to be injected into the Store
     abstract member Data : 'Format
     /// Optional metadata (null, or same as Data, not written if missing)
     abstract member Meta : 'Format

--- a/tests/FsCodec.SystemTextJson.Tests/CodecTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/CodecTests.fs
@@ -1,6 +1,7 @@
 module FsCodec.SystemTextJson.Tests.CodecTests
 
-open FsCodec.SystemTextJson // bring in ToByteArrayCodec etc extension methods
+open FsCodec.SystemTextJson
+open FsCodec.SystemTextJson.Interop // bring in ToUtf8Codec, ToJsonElementCodec extension methods
 open System.Text.Json
 open FsCheck.Xunit
 open Swensen.Unquote
@@ -14,12 +15,12 @@ type Union =
     | BO of EmbeddedWithOption
     interface TypeShape.UnionContract.IUnionContract
 
-let ignoreNullOptions = FsCodec.SystemTextJson.Options.Create(ignoreNulls = true)
-let elementEncoder : TypeShape.UnionContract.IEncoder<System.Text.Json.JsonElement> =
+let ignoreNullOptions = Options.Create(ignoreNulls = true)
+let elementEncoder : TypeShape.UnionContract.IEncoder<JsonElement> =
     FsCodec.SystemTextJson.Core.JsonElementEncoder(ignoreNullOptions) :> _
 
-let eventCodec = FsCodec.SystemTextJson.CodecJsonElement.Create<Union>(ignoreNullOptions)
-let multiHopCodec = eventCodec.ToUtf8Codec().ToByteArrayCodec().ToJsonElementCodec()
+let eventCodec = CodecJsonElement.Create<Union>(ignoreNullOptions)
+let multiHopCodec = eventCodec.ToUtf8Codec().ToJsonElementCodec()
 
 [<NoComparison>]
 type Envelope = { d : JsonElement }

--- a/tests/FsCodec.SystemTextJson.Tests/CodecTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/CodecTests.fs
@@ -18,8 +18,8 @@ let ignoreNullOptions = FsCodec.SystemTextJson.Options.Create(ignoreNulls = true
 let elementEncoder : TypeShape.UnionContract.IEncoder<System.Text.Json.JsonElement> =
     FsCodec.SystemTextJson.Core.JsonElementEncoder(ignoreNullOptions) :> _
 
-let eventCodec = FsCodec.SystemTextJson.Codec.Create<Union>(ignoreNullOptions)
-let doubleHopCodec = eventCodec.ToByteArrayCodec().ToJsonElementCodec()
+let eventCodec = FsCodec.SystemTextJson.CodecJsonElement.Create<Union>(ignoreNullOptions)
+let multiHopCodec = eventCodec.ToUtf8Codec().ToByteArrayCodec().ToJsonElementCodec()
 
 [<NoComparison>]
 type Envelope = { d : JsonElement }
@@ -66,5 +66,5 @@ let [<Property>] roundtrips value =
     test <@ expected = decoded @>
 
     // Also validate the adapters work when put in series (NewtonsoftJson tests are responsible for covering the individual hops)
-    let decodedDoubleHop = doubleHopCodec.TryDecode wrapped |> Option.get
-    test <@ expected = decodedDoubleHop @>
+    let decodedMultiHop = multiHopCodec.TryDecode wrapped |> Option.get
+    test <@ expected = decodedMultiHop @>


### PR DESCRIPTION
In Equinox V4, stores now accept/provide events in two primary formats (previously everything was `byte[]`):
- `ReadOnlyMemory<byte>`: Replaces `byte[]` as the default event body type, in order to facilitate pooling etc (EventStoreDB uses it directly, Equinox.DynamoStore maps internally to what the AWS SDK demands at present (`MemoryStream`))
- `JsonElement`: `Equinox.CosmosStore` now natively uses `System.Text.Json` so event bodies can be emitted cleanly and directly using that format

The key change is that `SystemTextJson` now has two `static type` roots;
- `CodecJsonElement`, which is for use with `Equinox.CosmosStore` V4 and later
- `Codec` (which previously produced a `JsonElement` codec) that needed to be adapted for use with `Equinox.CosmosStore` is now equivalent in signature to `Newtonsoft.Codec`, and works directly with all other stores