### PR TITLE
Remove net461; switch to net6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,15 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- `Newtonsoft.Json`: Rename `Settings` to `Options` [#60](https://github.com/jet/FsCodec/issues/60) [#76](https://github.com/jet/FsCodec/pull/76)
+- Updated build and tests to use `net6.0`, all test package dependencies
+- Updated to reference `TypeShape` v `10`, triggering min `FSharp.Core` target moving to `4.5.4` 
+
 ### Removed
+
+- `net461` support [#60](https://github.com/jet/FsCodec/issues/60) [#76](https://github.com/jet/FsCodec/pull/76)
+
 ### Fixed
 
 <a name="2.3.2"></a>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 ### Changed
 
-- `Newtonsoft.Json`: Rename `Settings` to `Options` [#60](https://github.com/jet/FsCodec/issues/60) [#76](https://github.com/jet/FsCodec/pull/76)
+- `NewtonsoftJson`: Rename `Settings` to `Options` [#60](https://github.com/jet/FsCodec/issues/60) [#76](https://github.com/jet/FsCodec/pull/76)
 - Updated build and tests to use `net6.0`, all test package dependencies
-- Updated to reference `TypeShape` v `10`, triggering min `FSharp.Core` target moving to `4.5.4` 
+- Updated `TypeShape` reference to v `10`, triggering min `FSharp.Core` target moving to `4.5.4` 
 
 ### Removed
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,9 +8,6 @@
     <PackageLicense>Apache-2.0</PackageLicense>
     <Copyright>Copyright © 2016-22</Copyright>
 
-    <TestTargetFrameworks>netcoreapp3.1;net461</TestTargetFrameworks>
-    <!-- avoid fighting with CI images about getting mono to run on MacOSX-->
-    <TestTargetFrameworks Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' ">net5.0</TestTargetFrameworks>
     <ThisDirAbsolute>$([System.IO.Path]::GetFullPath("$(MSBuildThisFileDirectory)"))</ThisDirAbsolute>
 
     <!-- Global Project config flags -->
@@ -21,18 +18,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <!-- disable sourcelink on mono, to workaround https://github.com/dotnet/sourcelink/issues/155 -->
-    <EnableSourceLink Condition=" '$(OS)' != 'Windows_NT' AND '$(MSBuildRuntimeType)' != 'Core' ">false</EnableSourceLink>
 
   </PropertyGroup>
 
-  <ItemGroup> <!-- net461 ref assemblies https://stackoverflow.com/a/57384175/11635 -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup> <!-- Avoid NRE on mono etc net461 -->
-    <Content Include="$(ThisDirAbsolute)tests/xunit.runner.json" Condition=" '$(OS)' != 'Windows_NT' AND '$(IsTestProject)' != 'false'">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # FsCodec [![Build Status](https://dev.azure.com/jet-opensource/opensource/_apis/build/status/jet.fscodec?branchName=master)](https://dev.azure.com/jet-opensource/opensource/_build/latest?definitionId=18?branchName=master) [![release](https://img.shields.io/github/release/jet/fscodec.svg)](https://github.com/jet/fscodec/releases) [![NuGet](https://img.shields.io/nuget/vpre/fscodec.svg?logo=nuget)](https://www.nuget.org/packages/fscodec/) [![license](https://img.shields.io/github/license/jet/fscodec.svg)](LICENSE)
 
-Defines a minimal interface for serialization and deserialization of events for event-sourcing systems on .NET.\
+Defines a minimal interface for serialization and deserialization of events for event-sourcing systems on .NET.
 Provides implementation packages for writing simple yet versionable Event Contract definitions in F# using ubiquitous serializers.
 
 Typically used in [applications](https://github.com/jet/dotnet-templates) leveraging [Equinox](https://github.com/jet/equinox) and/or [Propulsion](https://github.com/jet/propulsion), but also applicable to defining DTOs for other purposes such as Web APIs.
 
 ## Components
 
-The components within this repository are delivered as multi-targeted Nuget packages supporting `net461` (F# 3.1+) and `netstandard2.0`/`1` (F# 4.5+) profiles.
+The components within this repository are delivered as multi-targeted Nuget packages supporting `netstandard2.0`/`1` (F# 4.5+) profiles.
 
 - [![Codec NuGet](https://img.shields.io/nuget/v/FsCodec.svg)](https://www.nuget.org/packages/FsCodec/) `FsCodec` Defines interfaces with trivial implementation helpers.
   - No dependencies.
@@ -15,13 +15,13 @@ The components within this repository are delivered as multi-targeted Nuget pack
   - [`FsCodec.Codec`](https://github.com/jet/FsCodec/blob/master/src/FsCodec/Codec.fs#L5): enables plugging in a serializer and/or Union Encoder of your choice (typically this is used to supply a pair `encode` and `tryDecode` functions)
   - [`FsCodec.StreamName`](https://github.com/jet/FsCodec/blob/master/src/FsCodec/StreamName.fs): strongly-typed wrapper for a Stream Name, together with factory functions and active patterns for parsing same
 - [![Box Codec NuGet](https://img.shields.io/nuget/v/FsCodec.Box.svg)](https://www.nuget.org/packages/FsCodec.Box/) `FsCodec.Box`: See [`FsCodec.Box.Codec`](#boxcodec); `IEventCodec<obj>` implementation that provides a null encode/decode step in order to enable decoupling of serialization/deserialization concerns from the encoding aspect, typically used together with  [`Equinox.MemoryStore`](https://www.fuget.org/packages/Equinox.MemoryStore)
-  - [depends](https://www.fuget.org/packages/FsCodec.Box) on `FsCodec`, `TypeShape >= 8`
+  - [depends](https://www.fuget.org/packages/FsCodec.Box) on `FsCodec`, `TypeShape >= 10`
 - [![Newtonsoft.Json Codec NuGet](https://img.shields.io/nuget/v/FsCodec.NewtonsoftJson.svg)](https://www.nuget.org/packages/FsCodec.NewtonsoftJson/) `FsCodec.NewtonsoftJson`: As described in [a scheme for the serializing Events modelled as an F# Discriminated Union](https://eiriktsarpalis.wordpress.com/2018/10/30/a-contract-pattern-for-schemaless-datastores/), enabled tagging of F# Discriminated Union cases in a versionable manner with low-dependencies using [TypeShape](https://github.com/eiriktsarpalis/TypeShape)'s [`UnionContractEncoder`](https://eiriktsarpalis.wordpress.com/2018/10/30/a-contract-pattern-for-schemaless-datastores)
   - Uses the ubiquitous [`Newtonsoft.Json`](https://github.com/JamesNK/Newtonsoft.Json) library to serialize the event bodies.
   - Provides relevant Converters for common non-primitive types prevalent in F#
-  - [depends](https://www.fuget.org/packages/FsCodec.NewtonsoftJson) on `FsCodec`, `Newtonsoft.Json >= 11.0.2`, `TypeShape >= 8`, `Microsoft.IO.RecyclableMemoryStream >= 1.2.2`, `System.Buffers >= 4.5`
+  - [depends](https://www.fuget.org/packages/FsCodec.NewtonsoftJson) on `FsCodec`, `Newtonsoft.Json >= 11.0.2`, `TypeShape >= 10`, `Microsoft.IO.RecyclableMemoryStream >= 2.2.0`, `System.Buffers >= 4.5.1`
 - [![System.Text.Json Codec NuGet](https://img.shields.io/nuget/v/FsCodec.SystemTextJson.svg)](https://www.nuget.org/packages/FsCodec.SystemTextJson/) `FsCodec.SystemTextJson`: See [#38](https://github.com/jet/FsCodec/pulls/38): drop in replacement that allows one to retarget from `Newtonsoft.Json` to the .NET Core >= v 3.0 default serializer: `System.Text.Json`, solely by changing the referenced namespace.
-  - [depends](https://www.fuget.org/packages/FsCodec.SystemTextJson) on `FsCodec`, `System.Text.Json >= 6.0.1`, `TypeShape >= 9`
+  - [depends](https://www.fuget.org/packages/FsCodec.SystemTextJson) on `FsCodec`, `System.Text.Json >= 6.0.1`, `TypeShape >= 10`
 
 # Features: `FsCodec`
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,6 +37,11 @@ jobs:
   pool:
     vmImage: 'macOS-latest'
   steps:
+  - task: UseDotNet@2
+    displayName: 'Install .NET 6 sdk'
+    inputs:
+      packageType: sdk
+      version: 6.x
   - script: dotnet test build.proj
     displayName: dotnet test
   - task: PublishTestResults@2

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.200",
-    "rollForward": "latestFeature"
+    "version": "6.0.202",
+    "rollForward": "latestMajor"
   }
 }

--- a/src/FsCodec.Box/FsCodec.Box.fsproj
+++ b/src/FsCodec.Box/FsCodec.Box.fsproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <IsTestProject>false</IsTestProject>
         <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
         <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
     </PropertyGroup>
@@ -12,12 +11,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-        <PackageReference Include="MinVer" Version="2.5.0" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+        <PackageReference Include="MinVer" Version="3.1.0" PrivateAssets="All" />
 
-        <PackageReference Include="FSharp.Core" Version="4.3.4" />
+        <PackageReference Include="FSharp.Core" Version="4.5.4" />
 
-        <PackageReference Include="TypeShape" Version="8.0.0" />
+        <PackageReference Include="TypeShape" Version="10.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/FsCodec.NewtonsoftJson/Codec.fs
+++ b/src/FsCodec.NewtonsoftJson/Codec.fs
@@ -54,7 +54,7 @@ module Core =
 /// See <a href="https://github.com/eiriktsarpalis/TypeShape/blob/master/tests/TypeShape.Tests/UnionContractTests.fs" /> for example usage.</summary>
 type Codec private () =
 
-    static let defaultSettings = lazy Settings.Create()
+    static let defaultSettings = lazy Options.Create()
 
     /// <summary>Generate an <code>IEventCodec</code> using the supplied <c>Newtonsoft.Json</c> <c>settings</c>.<br/>
     /// Uses <c>up</c> and <c>down</c> functions to facilitate upconversion/downconversion
@@ -70,7 +70,7 @@ type Codec private () =
             ///   a <c>meta</c> object that will be serialized with the same settings (if it's not <c>None</c>)
             ///   and an Event Creation <c>timestamp</c>.</summary>
             down : 'Context option * 'Event -> 'Contract * 'Meta option * Guid * string * string * DateTimeOffset option,
-            /// <summary>Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Settings.Default</c></summary>
+            /// <summary>Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c></summary>
             [<Optional; DefaultParameterValue(null)>] ?settings,
             /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
@@ -116,7 +116,7 @@ type Codec private () =
             down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
             /// <summary>Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>correlationId</c> and c) the correlationId</summary>
             mapCausation : 'Context option * 'Meta option -> 'Meta option * Guid * string * string,
-            /// <summary>Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Settings.Default</c></summary>
+            /// <summary>Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c></summary>
             [<Optional; DefaultParameterValue(null)>] ?settings,
             /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
@@ -142,7 +142,7 @@ type Codec private () =
             ///   a <c>meta</c> object that will be serialized with the same settings (if it's not <c>None</c>)
             ///   and an Event Creation <c>timestamp</c>.</summary>
             down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
-            /// <summary>Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Settings.Default</c></summary>
+            /// <summary>Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c></summary>
             [<Optional; DefaultParameterValue(null)>] ?settings,
             /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
@@ -155,7 +155,7 @@ type Codec private () =
     /// The Event Type Names are inferred based on either explicit <c>DataMember(Name=</c> Attributes, or (if unspecified) the Discriminated Union Case Name
     /// <c>'Union</c> must be tagged with <c>interface TypeShape.UnionContract.IUnionContract</c> to signify this scheme applies.</summary>
     static member Create<'Union when 'Union :> TypeShape.UnionContract.IUnionContract>
-        (   /// <summary>Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Settings.Default</c></summary>
+        (   /// <summary>Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c></summary>
             [<Optional; DefaultParameterValue(null)>] ?settings,
             /// <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)

--- a/src/FsCodec.NewtonsoftJson/FsCodec.NewtonsoftJson.fsproj
+++ b/src/FsCodec.NewtonsoftJson/FsCodec.NewtonsoftJson.fsproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <IsTestProject>false</IsTestProject>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
@@ -19,16 +18,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="MinVer" Version="2.5.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="3.1.0" PrivateAssets="All" />
 
-    <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
-    <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
+    <PackageReference Include="FSharp.Core" Version="4.5.4" />
 
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="System.Buffers" Version="4.5.0" />
-    <PackageReference Include="TypeShape" Version="8.0.0" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="TypeShape" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FsCodec.NewtonsoftJson/FsCodec.NewtonsoftJson.fsproj
+++ b/src/FsCodec.NewtonsoftJson/FsCodec.NewtonsoftJson.fsproj
@@ -11,7 +11,7 @@
     <Compile Include="UnionConverter.fs" />
     <Compile Include="TypeSafeEnumConverter.fs" />
     <Compile Include="OptionConverter.fs" />
-    <Compile Include="Settings.fs" />
+    <Compile Include="Options.fs" />
     <Compile Include="Codec.fs" />
     <Compile Include="Serdes.fs" />
     <Compile Include="VerbatimUtf8Converter.fs" />

--- a/src/FsCodec.NewtonsoftJson/Options.fs
+++ b/src/FsCodec.NewtonsoftJson/Options.fs
@@ -5,13 +5,13 @@ open Newtonsoft.Json.Serialization
 open System
 open System.Runtime.InteropServices
 
-type Settings private () =
+type Options private () =
 
     static let defaultConverters : JsonConverter[] = [| OptionConverter() |]
 
-    static let def = lazy Settings.Create()
+    static let def = lazy Options.Create()
 
-    /// <summary>Analogous to <c>JsonSerializerOptions.Default</c> - allows for sharing/caching of the default profile as defined by <c>Settings.Create()</c></summary>
+    /// <summary>Analogous to <c>JsonSerializerOptions.Default</c> - allows for sharing/caching of the default profile as defined by <c>Options.Create()</c></summary>
     static member Default : JsonSerializerSettings = def.Value
 
     /// Creates a default set of serializer settings used by Json serialization. When used with no args, same as JsonSerializerSettings.CreateDefault()
@@ -60,7 +60,7 @@ type Settings private () =
             /// Error on missing values (as opposed to letting them just be default-initialized); defaults to false
             [<Optional; DefaultParameterValue(null)>] ?errorOnMissing : bool) =
 
-        Settings.CreateDefault(
+        Options.CreateDefault(
             converters = (match converters with null | [||] -> defaultConverters | xs -> Array.append defaultConverters xs),
             ?ignoreNulls = ignoreNulls,
             ?errorOnMissing = errorOnMissing,

--- a/src/FsCodec.NewtonsoftJson/Serdes.fs
+++ b/src/FsCodec.NewtonsoftJson/Serdes.fs
@@ -2,7 +2,7 @@ namespace FsCodec.NewtonsoftJson
 
 open Newtonsoft.Json
 
-/// Serializes to/from strings using the supplied Settings
+/// Serializes to/from strings using the supplied JsonSerializerSettings
 type Serdes(options : JsonSerializerSettings) =
 
     /// <summary>The <c>JsonSerializerSettings</c> used by this instance.</summary>

--- a/src/FsCodec.NewtonsoftJson/Serdes.fs
+++ b/src/FsCodec.NewtonsoftJson/Serdes.fs
@@ -1,8 +1,6 @@
 namespace FsCodec.NewtonsoftJson
 
-open FsCodec.NewtonsoftJson
 open Newtonsoft.Json
-open System.Runtime.InteropServices
 
 /// Serializes to/from strings using the supplied Settings
 type Serdes(options : JsonSerializerSettings) =
@@ -17,32 +15,3 @@ type Serdes(options : JsonSerializerSettings) =
     /// Deserializes value of given type from JSON string.
     member x.Deserialize<'T>(json : string) : 'T =
         JsonConvert.DeserializeObject<'T>(json, options)
-
-    /// Serializes given value to a JSON string.
-    [<System.Obsolete "Please use non-static Serdes instead">]
-    static member Serialize<'T>
-        (   /// Value to serialize.
-            value : 'T,
-            /// Use indentation when serializing JSON. Defaults to false.
-            [<Optional; DefaultParameterValue false>] ?indent : bool) : string =
-        let options = (if indent = Some true then Settings.Create(indent = true) else Settings.Default)
-        JsonConvert.SerializeObject(value, options)
-
-    /// Serializes given value to a JSON string with custom options
-    [<System.Obsolete "Please use non-static Serdes instead">]
-    static member Serialize<'T>
-        (   /// Value to serialize.
-            value : 'T,
-            /// Settings to use (use other overload to use Settings.Default profile)
-            settings : JsonSerializerSettings) : string =
-        JsonConvert.SerializeObject(value, settings)
-
-    /// Deserializes value of given type from JSON string.
-    [<System.Obsolete "Please use non-static Serdes instead">]
-    static member Deserialize<'T>
-        (   /// Json string to deserialize.
-            json : string,
-            /// Settings to use (defaults to Settings.Default profile)
-            [<Optional; DefaultParameterValue null>] ?settings : JsonSerializerSettings) : 'T =
-        let settings = match settings with Some x -> x | None -> Settings.Default
-        JsonConvert.DeserializeObject<'T>(json, settings)

--- a/src/FsCodec.SystemTextJson/FsCodec.SystemTextJson.fsproj
+++ b/src/FsCodec.SystemTextJson/FsCodec.SystemTextJson.fsproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <IsTestProject>false</IsTestProject>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
@@ -19,13 +18,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="MinVer" Version="2.5.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="3.1.0" PrivateAssets="All" />
 
-    <PackageReference Include="FSharp.Core" Version="4.3.4" />
+    <PackageReference Include="FSharp.Core" Version="4.5.4" />
 
     <PackageReference Include="System.Text.Json" Version="6.0.1" />
-    <PackageReference Include="TypeShape" Version="9.0.0" />
+    <PackageReference Include="TypeShape" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FsCodec.SystemTextJson/Serdes.fs
+++ b/src/FsCodec.SystemTextJson/Serdes.fs
@@ -1,6 +1,5 @@
 namespace FsCodec.SystemTextJson
 
-open System.Runtime.InteropServices
 open System.Text.Json
 
 /// Serializes to/from strings using the supplied Options
@@ -16,32 +15,3 @@ type Serdes(options : JsonSerializerOptions) =
     /// Deserializes value of given type from JSON string.
     member x.Deserialize<'T>(json : string) : 'T =
         JsonSerializer.Deserialize<'T>(json, options)
-
-    /// Serializes given value to a JSON string.
-    [<System.Obsolete "Please use non-static Serdes instead">]
-    static member Serialize<'T>
-        (   /// Value to serialize.
-            value : 'T,
-            /// Use indentation when serializing JSON. Defaults to false.
-            [<Optional; DefaultParameterValue false>] ?indent : bool) : string =
-        let options = (if indent = Some true then Options.Create(indent = true) else Options.Default)
-        JsonSerializer.Serialize<'T>(value, options)
-
-    /// Serializes given value to a JSON string with custom options
-    [<System.Obsolete "Please use non-static Serdes instead">]
-    static member Serialize<'T>
-        (   /// Value to serialize.
-            value : 'T,
-            /// Options to use (use other overload to use Options.Default profile)
-            options : JsonSerializerOptions) : string =
-        JsonSerializer.Serialize<'T>(value, options)
-
-    /// Deserializes value of given type from JSON string.
-    [<System.Obsolete "Please use non-static Serdes instead">]
-    static member Deserialize<'T>
-        (   /// Json string to deserialize.
-            json : string,
-            /// Options to use (defaults to Options.Default profile)
-            [<Optional; DefaultParameterValue null>] ?options : JsonSerializerOptions) : 'T =
-        let settings = match options with Some o -> o | None -> Options.Default
-        JsonSerializer.Deserialize<'T>(json, settings)

--- a/src/FsCodec/FsCodec.fsproj
+++ b/src/FsCodec/FsCodec.fsproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <IsTestProject>false</IsTestProject>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
@@ -14,11 +13,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="MinVer" Version="2.5.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="3.1.0" PrivateAssets="All" />
 
-    <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
-    <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
+    <PackageReference Include="FSharp.Core" Version="4.5.4" />
     <PackageReference Include="FSharp.UMX" Version="1.0.0" />
   </ItemGroup>
 

--- a/tests/FsCodec.NewtonsoftJson.Tests/Examples.fsx
+++ b/tests/FsCodec.NewtonsoftJson.Tests/Examples.fsx
@@ -23,7 +23,7 @@ module Contract =
 
     type Item = { value : string option }
     // implies an OptionConverter will be applied
-    let private serdes = Serdes Settings.Default
+    let private serdes = Serdes Options.Default
     let serialize (x : Item) : string = serdes.Serialize x
     let deserialize (json : string) = serdes.Deserialize json
 
@@ -32,13 +32,13 @@ module Contract2 =
     type TypeThatRequiresMyCustomConverter = { mess : int }
     type MyCustomConverter() = inherit JsonPickler<string>() override _.Read(_,_) = "" override _.Write(_,_,_) = ()
     type Item = { Value : string option; other : TypeThatRequiresMyCustomConverter }
-    /// Settings to be used within this contract
+    /// Options to be used within this contract
     // note OptionConverter is also included by default; Value field will write as `"value"`
-    let private serdes = Settings.Create(MyCustomConverter(), camelCase = true) |> FsCodec.NewtonsoftJson.Serdes
+    let private serdes = Options.Create(MyCustomConverter(), camelCase = true) |> FsCodec.NewtonsoftJson.Serdes
     let serialize (x : Item) = serdes.Serialize x
     let deserialize (json : string) : Item = serdes.Deserialize json
 
-let private serdes = Settings.Default |> Serdes
+let private serdes = Options.Default |> Serdes
 let inline ser x = serdes.Serialize(x)
 let inline des<'t> x = serdes.Deserialize<'t>(x)
 
@@ -61,7 +61,7 @@ ser { a = "testing"; b = Guid.Empty }
 ser Guid.Empty
 // "00000000-0000-0000-0000-000000000000"
 
-let serdesWithGuidConverter = Settings.Create(converters = [| GuidConverter() |]) |> Serdes
+let serdesWithGuidConverter = Options.Create(converters = [| GuidConverter() |]) |> Serdes
 serdesWithGuidConverter.Serialize(Guid.Empty)
 // 00000000000000000000000000000000
 

--- a/tests/FsCodec.NewtonsoftJson.Tests/FsCodec.NewtonsoftJson.Tests.fsproj
+++ b/tests/FsCodec.NewtonsoftJson.Tests/FsCodec.NewtonsoftJson.Tests.fsproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,8 +16,7 @@
   <ItemGroup>
     <PackageReference Include="FsCheck.Xunit" Version="2.14.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="Unquote" Version="6.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />

--- a/tests/FsCodec.NewtonsoftJson.Tests/PicklerTests.fs
+++ b/tests/FsCodec.NewtonsoftJson.Tests/PicklerTests.fs
@@ -36,8 +36,8 @@ let [<Fact>] ``Tagging with GuidConverter`` () =
 let [<Fact>] ``Global GuidConverter`` () =
     let value = Guid.Empty
 
-    let resDashes = JsonConvert.SerializeObject(value, Settings.Default)
-    let resNoDashes = JsonConvert.SerializeObject(value, Settings.Create(GuidConverter()))
+    let resDashes = JsonConvert.SerializeObject(value, Options.Default)
+    let resNoDashes = JsonConvert.SerializeObject(value, Options.Create(GuidConverter()))
 
     test <@ "\"00000000-0000-0000-0000-000000000000\"" = resDashes
             && "\"00000000000000000000000000000000\"" = resNoDashes @>

--- a/tests/FsCodec.NewtonsoftJson.Tests/SomeNullHandlingTests.fs
+++ b/tests/FsCodec.NewtonsoftJson.Tests/SomeNullHandlingTests.fs
@@ -21,16 +21,16 @@ open FsCodec.NewtonsoftJson
 open Swensen.Unquote
 open Xunit
 
-let ootb = Settings.CreateDefault() |> Serdes
-let serdes = Serdes Settings.Default
+let ootb = Options.CreateDefault() |> Serdes
+let serdes = Serdes Options.Default
 
-let [<Fact>] ``Settings.CreateDefault roundtrips null string option, but rendering is ugly`` () =
+let [<Fact>] ``Options.CreateDefault roundtrips null string option, but rendering is ugly`` () =
     let value : string option = Some null
     let ser = ootb.Serialize value
     test <@ ser = "{\"Case\":\"Some\",\"Fields\":[null]}" @>
     test <@ value = ootb.Deserialize ser @>
 
-let [<Fact>] ``Settings.Create does not roundtrip Some null`` () =
+let [<Fact>] ``Options.Create does not roundtrip Some null`` () =
     let value : string option = Some null
     let ser = serdes.Serialize value
     "null" =! ser
@@ -58,7 +58,7 @@ let [<Fact>] ``Workaround is to detect and/or substitute such non-roundtrippable
 type RecordWithStringOptions = { x : int; y : Nested }
 and Nested = { z : string option }
 
-let [<Fact>] ``Can detect and/or substitute null string option when using Options/Settings.Create`` () =
+let [<Fact>] ``Can detect and/or substitute null string option when using Options.Create`` () =
     let value : RecordWithStringOptions = { x = 9; y = { z = Some null } }
     test <@ hasSomeNull value @>
     let value = replaceSomeNullsWithNone value
@@ -72,7 +72,7 @@ let [<Fact>] ``Can detect and/or substitute null string option when using Option
     let ignoreNullsSerdes = Options.Create(ignoreNulls = true) |> Serdes
 #else
     // As one might expect, the ignoreNulls setting is also honored
-    let ignoreNullsSerdes = Settings.Create(ignoreNulls = true) |> Serdes
+    let ignoreNullsSerdes = Options.Create(ignoreNulls = true) |> Serdes
 #endif
     let ser = ignoreNullsSerdes.Serialize value
     ser =! """{"x":9,"y":{}}"""

--- a/tests/FsCodec.NewtonsoftJson.Tests/UnionConverterTests.fs
+++ b/tests/FsCodec.NewtonsoftJson.Tests/UnionConverterTests.fs
@@ -88,7 +88,7 @@ let assertIgnoreNullsIs value (profile : JsonSerializerOptions) =
     profile.DefaultIgnoreCondition =! if value then JsonIgnoreCondition.Always else JsonIgnoreCondition.Never
 #else
 let serializeWith<'t> (profile : JsonSerializerSettings) (value : 't) = JsonConvert.SerializeObject(value, profile)
-let settings = Settings.Create(camelCase = false, ignoreNulls = true)
+let settings = Options.Create(camelCase = false, ignoreNulls = true)
 let serializeDefault<'t> value = serializeWith<'t> settings value
 
 let deserializeWith<'t> (profile : JsonSerializerSettings) serialized = JsonConvert.DeserializeObject<'t>(serialized, profile)
@@ -168,8 +168,8 @@ let ``deserializes properly`` () =
 #if SYSTEM_TEXT_JSON
     let requiredSettingsToHandleOptionalFields = Options.Default
 #else
-    // This is equivalent to Settings.Default, but we want absolutely minimal adjustment from the out-of-the-box Newtonsoft settings
-    let requiredSettingsToHandleOptionalFields = Settings.CreateDefault(OptionConverter())
+    // This is equivalent to Options.Default, but we want absolutely minimal adjustment from the out-of-the-box Newtonsoft settings
+    let requiredSettingsToHandleOptionalFields = Options.CreateDefault(OptionConverter())
 #endif
     let deserializeCustom s = deserializeWith<TestDU> requiredSettingsToHandleOptionalFields s
     test <@ CaseM (Some 1) = deserializeCustom """{"case":"CaseM","a":1}""" @>
@@ -186,8 +186,8 @@ module MissingFieldsHandling =
 
     let rejectMissingSettings =
         [   JsonSerializerSettings(MissingMemberHandling = MissingMemberHandling.Error)
-            Settings.CreateDefault(errorOnMissing=true)
-            Settings.Create(errorOnMissing=true)]
+            Options.CreateDefault(errorOnMissing=true)
+            Options.Create(errorOnMissing=true)]
 
     [<Fact>]
     let ``lets converters reject missing values by feeding them a null`` () =
@@ -235,7 +235,7 @@ let (|Q|) (s: string) = JsonSerializer.Serialize(s, defaultOptions)
 // Renderings when NullValueHandling=Include, which is used by the recommended Options.Create profile
 #else
 let (|Q|) (s: string) = Newtonsoft.Json.JsonConvert.SerializeObject s
-// Renderings when NullValueHandling=Include, which is the default for Json.net, and used by the recommended Settings.CreateCorrect profile
+// Renderings when NullValueHandling=Include, which is the default for Json.net, and used by the recommended Options.Create profile
 #endif
 let render ignoreNulls = function
     | CaseA { test = null } when ignoreNulls -> """{"case":"CaseA"}"""
@@ -323,7 +323,7 @@ let roundtripProperty ignoreNulls profile value =
 #if SYSTEM_TEXT_JSON
 let includeNullsProfile = Options.Create(ignoreNulls = false)
 #else
-let includeNullsProfile = Settings.CreateDefault(OptionConverter() (*, ignoreNulls=false*))
+let includeNullsProfile = Options.CreateDefault(OptionConverter() (*, ignoreNulls=false*))
 #endif
 [<DomainProperty(MaxTest=1000)>]
 let ``UnionConverter includeNulls Profile roundtrip property test`` (x: TestDU) =
@@ -334,7 +334,7 @@ let ``UnionConverter includeNulls Profile roundtrip property test`` (x: TestDU) 
 #if SYSTEM_TEXT_JSON
 let defaultProfile = Options.Default
 #else
-let defaultProfile = Settings.Default
+let defaultProfile = Options.Default
 #endif
 [<DomainProperty(MaxTest=1000)>]
 let ``UnionConverter opinionated Profile roundtrip property test`` (x: TestDU) =
@@ -542,7 +542,7 @@ module ``Struct discriminated unions`` =
 #if SYSTEM_TEXT_JSON
 let serdes = Serdes Options.Default
 #else
-let serdes = Serdes Settings.Default
+let serdes = Serdes Options.Default
 #endif
 
 module Nested =

--- a/tests/FsCodec.NewtonsoftJson.Tests/VerbatimUtf8ConverterTests.fs
+++ b/tests/FsCodec.NewtonsoftJson.Tests/VerbatimUtf8ConverterTests.fs
@@ -70,7 +70,7 @@ module VerbatimUtf8Tests = // not a module or CI will fail for net461
         let decoded = eventCodec.TryDecode loaded |> Option.get
         input =! decoded
 
-    let defaultSettings = Settings.CreateDefault()
+    let defaultSettings = Options.CreateDefault()
     let defaultEventCodec = Codec.Create<U>(defaultSettings)
 
     let [<Property>] ``round-trips diverse bodies correctly`` (x: U) =

--- a/tests/FsCodec.SystemTextJson.Tests/FsCodec.SystemTextJson.Tests.fsproj
+++ b/tests/FsCodec.SystemTextJson.Tests/FsCodec.SystemTextJson.Tests.fsproj
@@ -1,15 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>net6.0</TargetFramework>
     <DefineConstants>SYSTEM_TEXT_JSON</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FsCheck.Xunit" Version="2.14.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="Unquote" Version="6.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />

--- a/tests/FsCodec.SystemTextJson.Tests/InteropTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/InteropTests.fs
@@ -32,7 +32,7 @@ type U =
     | N
     interface TypeShape.UnionContract.IUnionContract
 
-let defaultSettings = FsCodec.NewtonsoftJson.Settings.CreateDefault() // Test without converters, as that's what Equinox.Cosmos will do
+let defaultSettings = FsCodec.NewtonsoftJson.Options.CreateDefault() // Test without converters, as that's what Equinox.Cosmos will do
 let defaultEventCodec = FsCodec.NewtonsoftJson.Codec.Create<U>(defaultSettings)
 let indirectCodecU = FsCodec.SystemTextJson.Codec.Create<U>() |> FsCodec.SystemTextJson.InteropExtensions.ToByteArrayCodec
 

--- a/tests/FsCodec.Tests/FsCodec.Tests.fsproj
+++ b/tests/FsCodec.Tests/FsCodec.Tests.fsproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,8 +9,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="Unquote" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Unquote" Version="6.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>


### PR DESCRIPTION
Main material change is to rename `NewtonsoftJson.Settings` to `Options` to align naming for ease of migrating between serializers.
Removing cruft as there are breaking changes on the way

resolves #60 