### PR TITLE
Struct Tuples/Options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `TimelineEvent.Size`: Enables stores to surface the stored size at the point of loading [#82](https://github.com/jet/FsCodec/pull/82)
+
 ### Changed
 
 - `Option/Tuple`: Replace with `ValueOption`/`ValueTuple` [#82](https://github.com/jet/FsCodec/pull/82)
+- `Codec 'Context`: replace `'Context option` with `Context` [#82](https://github.com/jet/FsCodec/pull/82)
 
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- `Option/Tuple`: Replace with `ValueOption`/`ValueTuple` [#82](https://github.com/jet/FsCodec/pull/82)
+
 ### Removed
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ _See [tests/FsCodec.NewtonsoftJson.Tests/Examples.fsx](tests/FsCodec.NewtonsoftJ
 /// Defines a contract interpreter that encodes and/or decodes events representing the known set of events borne by a stream category
 type IEventCodec<'Event, 'Format, 'Context> =
     /// Encodes a <c>'Event</c> instance into a <c>'Format</c> representation
-    abstract Encode : context: 'Context voption * value: 'Event -> IEventData<'Format>
+    abstract Encode : context: 'Context * value: 'Event -> IEventData<'Format>
     /// Decodes a formatted representation into a <c>'Event<c> instance. Does not throw exception on undefined <c>EventType</c>s
     abstract TryDecode : encoded: ITimelineEvent<'Format> -> 'Event voption
 ```

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ type IEventCodec<'Event, 'Format, 'Context> =
     /// Encodes a <c>'Event</c> instance into a <c>'Format</c> representation
     abstract Encode : context: 'Context voption * value: 'Event -> IEventData<'Format>
     /// Decodes a formatted representation into a <c>'Event<c> instance. Does not throw exception on undefined <c>EventType</c>s
-    abstract TryDecode : encoded: ITimelineEvent<'Format> -> 'Event option
+    abstract TryDecode : encoded: ITimelineEvent<'Format> -> 'Event voption
 ```
 
 `IEventCodec` represents a standard contract for the encoding and decoding of events used in event sourcing and event based notification scenarios:
@@ -416,7 +416,7 @@ module Events =
     let codec = FsCodec.NewtonsoftJson.Codec.Create<Event>()
 
     // See "logging unmatched events" later in this section for information about this wrapping using an EventCodec helper
-    let (|TryDecode|_|) stream = EventCodec.tryDecode codec Serilog.Log.Logger stream
+    let [<return: Struct>] (|TryDecode|_|) stream = EventCodec.tryDecode codec Serilog.Log.Logger stream
 ```
 
 <a name="umx"></a>
@@ -478,19 +478,18 @@ module StreamName =
 
     (* Rendering *)
 
-
     let toString (streamName : StreamName) : string = UMX.untag streamName
 
     (* Parsing: Raw Stream name Validation functions/pattern that handle malformed cases without throwing *)
 
     // Attempts to split a Stream Name in the form {category}-{id} into its two elements.
     // The {id} segment is permitted to include embedded '-' (dash) characters
-    let trySplitCategoryAndId (rawStreamName : string) : (string * string) option = ...
+    let trySplitCategoryAndId (rawStreamName : string) : (string * string) voption = ...
 
     // Attempts to split a Stream Name in the form {category}-{id} into its two elements.
     // The {id} segment is permitted to include embedded '-' (dash) characters
     // Yields <code>NotCategorized</code> if it does not adhere to that form.
-    let (|Categorized|NotCategorized|) (rawStreamName : string) : Choice<string*string,unit> = ...
+    let (|Categorized|NotCategorized|) (rawStreamName : string) : Choice<struct (string*string), unit> = ...
 
     (* Splitting: functions/Active patterns for (i.e. generated via `parse`, `create` or `compose`) well-formed Stream Names
        Will throw if presented with malformed strings [generated via alternate means] *)
@@ -498,8 +497,8 @@ module StreamName =
     // Splits a well-formed Stream Name of the form {category}-{id} into its two elements.
     // Throws <code>InvalidArgumentException</code> if it does not adhere to the well known format (i.e. if it was not produced by `parse`).
     // <remarks>Inverse of <code>create</code>
-    let splitCategoryAndId (streamName : StreamName) : string * string = ...
-    let (|CategoryAndId|) : StreamName -> (string * string) = splitCategoryAndId
+    let splitCategoryAndId (streamName : StreamName) : struct (string * string) = ...
+    let (|CategoryAndId|) : StreamName -> struct (string * string) = splitCategoryAndId
 
     // Splits a `_`-separated set of id elements (as formed by `compose`) into its (one or more) constituent elements.
     // <remarks>Inverse of what <code>compose</code> does to the subElements
@@ -508,8 +507,8 @@ module StreamName =
     // Splits a well-formed Stream Name of the form {category}-{id1}_{id2}_{idN} into a pair of category and ids
     // Throws <code>InvalidArgumentException</code> if it does not adhere to the well known format (i.e. if it was not produced by `parse`).
     // <remarks>Inverse of <code>create</code>
-    let splitCategoryAndIds (streamName : StreamName) : string * string[] = ...
-    let (|CategoryAndIds|) : StreamName -> (string * string[]) = splitCategoryAndIds
+    let splitCategoryAndIds (streamName : StreamName) : struct (string * string)[] = ...
+    let (|CategoryAndIds|) : StreamName -> struct (string * string[]) = splitCategoryAndIds
 ```
 
 ## Decoding events
@@ -534,7 +533,7 @@ and the helpers defined above, we can route and/or filter them as follows:
 ```fsharp
 let runCodec () =
     for stream, event in events do
-        match stream, event with
+        match struct (stream, event) with
         | StreamName.Category (Events.Category, ClientId.Parse id), (Events.Decode stream e) ->
             printfn "Client %s, event %A" (ClientId.toString id) e
         | StreamName.Category (cat, id), e ->
@@ -562,6 +561,7 @@ There are two events that we were not able to decode, for varying reasons:
 _Note however, that we don't have a clean way to trap the data and log it. See [Logging unmatched events](#logging-unmatched-events) for an example of how one might log such unmatched events_
 
 ### Handling introduction of new fields in JSON
+
 The below example demonstrates the addition of a `CartId` property in a newer version of `CreateCart`. It's worth noting that
 deserializing `CartV1.CreateCart` into `CartV2.CreateCart` requires `CartId` to be an optional property or the property will
 deserialize into `null` which is an invalid state for the `CartV2.CreateCart` record in F# (F# `type`s are assumed to never be `null`).
@@ -587,6 +587,7 @@ order to provide an F# only experience.
 
 The aim is to provide helpers to smooth the way for using reflection based serialization in a way that would not surprise
 people coming from a C# background and/or in mixed C#/F# codebases.
+
 ## Adding Matchers to the Event Contract
 
 We can clarify the consuming code a little by adding further helper Active Patterns alongside the event contract :-
@@ -598,23 +599,24 @@ module Events =
 
     // Pattern to determine whether a given {category}-{aggregateId} StreamName represents the stream associated with this Aggregate
     // Yields a strongly typed id from the aggregateId if the Category does match
-    let (|StreamName|_|) = function
+    let [<return: Struct>] (|StreamName|_|) = function
         | FsCodec.StreamName.CategoryAndId (Category, ClientId.Parse clientId) -> Some clientId
         | _ -> None
 
     // ... (as above)
 
     // Yields decoded events and relevant strongly typed ids if the category of the Stream Name is correct
-    let (|Match|_|) (streamName, event) =
-        match streamName, event with
-        | MatchesCategory clientId, TryDecode streamName e -> Some (clientId, e)
-        | _ -> None
+    let [<return: Struct>] (|Match|_|) (streamName, event) =
+        match struct (streamName, event) with
+        | MatchesCategory clientId, TryDecode streamName e -> ValueSome struct (clientId, e)
+        | _ -> ValueNone
         
-    let (|Decode|) stream = Seq.choose ((|TryDecode|_|) stream)
-    let (|Parse|_|) (streamName, span) =
+    module ValueOption = let toOption = function ValueSome x -> Some x | ValueNone -> None
+    let (|Decode|) stream = Seq.choose ((|TryDecode|_|) stream >> ValueOption.toOption)
+    let [<return: Struct>] (|Parse|_|) struct (streamName, span) =
         match streamName, span with
-        | Events.MatchesCategory clientId, Decode streamName es -> Some (clientId, es)
-        | _ -> None
+        | Events.MatchesCategory clientId, Decode streamName es -> ValueSome struct (clientId, es)
+        | _ -> ValueNone
 ```
 
 That boxes off the complex pattern matching close to the contract itself, and lets us match on the events in a handler as follows:
@@ -622,7 +624,7 @@ That boxes off the complex pattern matching close to the contract itself, and le
 ```fsharp
 let runCodecCleaner () =
     for stream, event in events do
-        match stream, event with
+        match struct (stream, event) with
         | Events.Match (clientId, event) ->
             printfn "Client %s, event %A" (ClientId.toString clientId) event
         | StreamName.CategoryAndId (cat, id), e ->
@@ -679,34 +681,35 @@ A clean way to wrap such a set of transitions is as follows:
 ```fsharp
 module Reactions =
 
-    type Event = int64 * DateTimeOffset * Events.Event
+    type Event = (struct (int64 * DateTimeOffset * Events.Event))
     let codec =
-        let up (raw : FsCodec.ITimelineEvent<ReadOnlyMemory<byte>>, contract : Events.Event) : Event = raw.Index, raw.Timestamp, contract
-        let down ((_index, timestamp, event) : Event) = event, None, Some timestamp
+        let up (raw : FsCodec.ITimelineEvent<ReadOnlyMemory<byte>>, contract : Events.Event) : Event = (raw.Index, raw.Timestamp, contract)
+        let down ((_index, timestamp, event) : Event) = struct (event, ValueNone, ValueSome timestamp)
         FsCodec.NewtonsoftJson.Codec.Create(up, down)
         
-    let (|TryDecode|_|) stream event : Event option = EventCodec.tryDecode codec Serilog.Log.Logger stream event
-    let (|Match|_|) (streamName, event) =
+    let [<return: Struct>] (|TryDecode|_|) stream event : Event option = EventCodec.tryDecode codec Serilog.Log.Logger stream event
+    let [<return: Struct>] (|Match|_|) (streamName, event) =
         match streamName, event with
         | Events.MatchesCategory clientId, TryDecode streamName event -> Some (clientId, event)
         | _ -> None
         
-    let (|Decode|) stream = Seq.choose ((|TryDecode|_|) stream)
-    let (|Parse|_|) (streamName, span) =
+    module ValueOption = let toOption = function ValueSome x -> Some x | ValueNone -> None
+    let (|Decode|) stream = Seq.choose ((|TryDecode|_|) stream >> ValueOption.toOption)
+    let [<return: Struct>] (|Parse|_|) struct (streamName, span) =
         match streamName, span with
-        | Events.MatchesCategory clientId, Decode streamName es -> Some (clientId, es)
-        | _ -> None        
+        | Events.MatchesCategory clientId, Decode streamName es -> ValueSome struct (clientId, es)
+        | _ -> ValueNone        
 ```
 
 This allows us to tweak the `runCodec` above as follows to also surface additional contextual information:
 
 ```fsharp
 let runWithContext () =
-    for stream, event in events do
+    for struct (stream, event) in events do
         match stream, event with
         | Reactions.Match (clientId, (index, ts, e)) ->
             printfn "Client %s index %d time %O event %A" (ClientId.toString clientId) index (ts.ToString "u") e
-        | FsCodec.StreamName.CategoryAndId (cat, id), e ->
+        | StreamName.CategoryAndId (cat, id), e ->
             printfn "Unhandled Event: Category %s, Id %s, Index %d, Event: %A " cat id e.Index e.EventType
 ```
 

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ _See [tests/FsCodec.NewtonsoftJson.Tests/Examples.fsx](tests/FsCodec.NewtonsoftJ
 /// Defines a contract interpreter that encodes and/or decodes events representing the known set of events borne by a stream category
 type IEventCodec<'Event, 'Format, 'Context> =
     /// Encodes a <c>'Event</c> instance into a <c>'Format</c> representation
-    abstract Encode : context: 'Context option * value: 'Event -> IEventData<'Format>
+    abstract Encode : context: 'Context voption * value: 'Event -> IEventData<'Format>
     /// Decodes a formatted representation into a <c>'Event<c> instance. Does not throw exception on undefined <c>EventType</c>s
     abstract TryDecode : encoded: ITimelineEvent<'Format> -> 'Event option
 ```

--- a/src/FsCodec.Box/Codec.fs
+++ b/src/FsCodec.Box/Codec.fs
@@ -70,7 +70,7 @@ type Codec private () =
             down : 'Event -> struct ('Contract * 'Meta voption * DateTimeOffset voption),
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
-        : FsCodec.IEventCodec<'Event, obj, obj> =
+        : FsCodec.IEventCodec<'Event, obj, unit> =
         FsCodec.Core.Codec.Create(DefaultEncoder, up, down, ?rejectNullaryCases = rejectNullaryCases)
 
     /// <summary>Generate an <c>IEventCodec</c> that handles <c>obj</c> (boxed .NET <c>Object</c>) Event Bodies.<br/>
@@ -79,5 +79,5 @@ type Codec private () =
     static member Create<'Union when 'Union :> TypeShape.UnionContract.IUnionContract>
         (   // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
-        : FsCodec.IEventCodec<'Union, obj, obj> =
+        : FsCodec.IEventCodec<'Union, obj, unit> =
         FsCodec.Core.Codec.Create(DefaultEncoder, ?rejectNullaryCases = rejectNullaryCases)

--- a/src/FsCodec.Box/Codec.fs
+++ b/src/FsCodec.Box/Codec.fs
@@ -27,7 +27,7 @@ type Codec private () =
             // <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c><br/>
             // The function is also expected to derive an optional <c>meta</c> object that will be serialized with the same <c>encoder</c>,
             // and <c>eventId</c>, <c>correlationId</c>, <c>causationId</c> and an Event Creation<c>timestamp</c></summary>.
-            down : struct ('Context voption * 'Event) -> struct ('Contract * 'Meta voption * Guid * string * string * DateTimeOffset voption),
+            down : struct ('Context * 'Event) -> struct ('Contract * 'Meta voption * Guid * string * string * DateTimeOffset voption),
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, obj, 'Context> =
@@ -48,7 +48,7 @@ type Codec private () =
             //   and an Event Creation <c>timestamp</c>.</summary>
             down : 'Event -> struct ('Contract * 'Meta voption * DateTimeOffset voption),
             // <summary>Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>eventId</c> c) the <c>correlationId</c> and d) the <c>causationId</c></summary>
-            mapCausation : struct ('Context voption * 'Meta voption) -> struct ('Meta voption * Guid * string * string),
+            mapCausation : struct ('Context * 'Meta voption) -> struct ('Meta voption * Guid * string * string),
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, obj, 'Context> =

--- a/src/FsCodec.Box/Codec.fs
+++ b/src/FsCodec.Box/Codec.fs
@@ -23,11 +23,11 @@ type Codec private () =
     static member Create<'Event, 'Contract, 'Meta, 'Context when 'Contract :> TypeShape.UnionContract.IUnionContract>
         (   // <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
             // to the <c>'Event</c> representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
-            up : FsCodec.ITimelineEvent<obj> * 'Contract -> 'Event,
+            up : struct (FsCodec.ITimelineEvent<obj> * 'Contract) -> 'Event,
             // <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c><br/>
             // The function is also expected to derive an optional <c>meta</c> object that will be serialized with the same <c>encoder</c>,
             // and <c>eventId</c>, <c>correlationId</c>, <c>causationId</c> and an Event Creation<c>timestamp</c></summary>.
-            down : 'Context option * 'Event -> 'Contract * 'Meta option * Guid * string * string * DateTimeOffset option,
+            down : struct ('Context voption * 'Event) -> struct ('Contract * 'Meta voption * Guid * string * string * DateTimeOffset voption),
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, obj, 'Context> =
@@ -41,14 +41,14 @@ type Codec private () =
     static member Create<'Event, 'Contract, 'Meta, 'Context when 'Contract :> TypeShape.UnionContract.IUnionContract>
         (   // <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
             // to the representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
-            up : FsCodec.ITimelineEvent<obj> * 'Contract -> 'Event,
+            up : struct (FsCodec.ITimelineEvent<obj> * 'Contract) -> 'Event,
             // <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
             // The function is also expected to derive
             //   a <c>meta</c> object that will be serialized with the same options (if it's not <c>None</c>)
             //   and an Event Creation <c>timestamp</c>.</summary>
-            down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
+            down : 'Event -> struct ('Contract * 'Meta voption * DateTimeOffset voption),
             // <summary>Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>eventId</c> c) the <c>correlationId</c> and d) the <c>causationId</c></summary>
-            mapCausation : 'Context option * 'Meta option -> 'Meta option * Guid * string * string,
+            mapCausation : struct ('Context voption * 'Meta voption) -> struct ('Meta voption * Guid * string * string),
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, obj, 'Context> =
@@ -62,12 +62,12 @@ type Codec private () =
     static member Create<'Event, 'Contract, 'Meta when 'Contract :> TypeShape.UnionContract.IUnionContract>
         (   // <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
             // to the representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
-            up : FsCodec.ITimelineEvent<obj> * 'Contract -> 'Event,
+            up : struct (FsCodec.ITimelineEvent<obj> * 'Contract) -> 'Event,
             // <summary>Maps a fresh <c>'Event</c> resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
             // The function is also expected to derive
             //   a <c>meta</c> object that will be serialized with the same options (if it's not <c>None</c>)
             //   and an Event Creation <c>timestamp</c>.</summary>
-            down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
+            down : 'Event -> struct ('Contract * 'Meta voption * DateTimeOffset voption),
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, obj, obj> =

--- a/src/FsCodec.Box/CoreCodec.fs
+++ b/src/FsCodec.Box/CoreCodec.fs
@@ -71,7 +71,7 @@ type Codec private () =
 
         let down struct (context, union) =
             let struct (c, m, t) = down union
-            let struct (m', eventId, correlationId, causationId) = mapCausation struct (context, m)
+            let struct (m', eventId, correlationId, causationId) = mapCausation (context, m)
             struct (c, m', eventId, correlationId, causationId, t)
         Codec.Create(encoder, up = up, down = down, ?rejectNullaryCases = rejectNullaryCases)
 

--- a/src/FsCodec.Box/CoreCodec.fs
+++ b/src/FsCodec.Box/CoreCodec.fs
@@ -18,11 +18,11 @@ type Codec private () =
         (   encoder,
             // <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
             // to the <c>'Event</c> representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
-            up : FsCodec.ITimelineEvent<'Body> * 'Contract -> 'Event,
+            up : struct (FsCodec.ITimelineEvent<'Body> * 'Contract) -> 'Event,
             // <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c><br/>
             // The function is also expected to derive an optional <c>meta</c> object that will be serialized with the same <c>encoder</c>,
             // and <c>eventId</c>, <c>correlationId</c>, <c>causationId</c> and an Event Creation<c>timestamp</c></summary>.
-            down : 'Context option * 'Event -> 'Contract * 'Meta option * Guid * string * string * DateTimeOffset option,
+            down : struct ('Context voption * 'Event) -> struct ('Contract * 'Meta voption * Guid * string * string * DateTimeOffset voption),
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, 'Body, 'Context> =
@@ -37,10 +37,11 @@ type Codec private () =
 
         { new FsCodec.IEventCodec<'Event, 'Body, 'Context> with
             member _.Encode(context, event) =
-                let (c, meta : 'Meta option, eventId, correlationId, causationId, timestamp : DateTimeOffset option) = down (context, event)
+                let struct (c, meta : 'Meta voption, eventId, correlationId, causationId, timestamp : DateTimeOffset voption) = down struct (context, event)
                 let enc = dataCodec.Encode c
-                let meta' = match meta with Some x -> encoder.Encode<'Meta> x | None -> Unchecked.defaultof<_>
-                EventData.Create(enc.CaseName, enc.Payload, meta', eventId, correlationId, causationId, ?timestamp = timestamp)
+                let meta' = match meta with ValueSome x -> encoder.Encode<'Meta> x | ValueNone -> Unchecked.defaultof<_>
+                let ts = match timestamp with ValueNone -> None | ValueSome v -> Some v
+                EventData.Create(enc.CaseName, enc.Payload, meta', eventId, correlationId, causationId, ?timestamp = ts)
 
             member _.TryDecode encoded =
                 match dataCodec.TryDecode { CaseName = encoded.EventType; Payload = encoded.Data } with
@@ -56,22 +57,22 @@ type Codec private () =
         (   encoder,
             // <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
             // to the representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
-            up : FsCodec.ITimelineEvent<'Body> * 'Contract -> 'Event,
+            up : struct (FsCodec.ITimelineEvent<'Body> * 'Contract) -> 'Event,
             // <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
             // The function is also expected to derive
             //   a <c>meta</c> object that will be serialized with the same options (if it's not <c>None</c>)
             //   and an Event Creation <c>timestamp</c>.</summary>
-            down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
+            down : 'Event -> struct ('Contract * 'Meta voption * DateTimeOffset voption),
             // <summary>Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>eventId</c> c) the <c>correlationId</c> and d) the <c>causationId</c></summary>
-            mapCausation : 'Context option * 'Meta option -> 'Meta option * Guid * string * string,
+            mapCausation : struct ('Context voption * 'Meta voption) -> struct ('Meta voption * Guid * string * string),
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, 'Body, 'Context> =
 
-        let down (context, union) =
-            let c, m, t = down union
-            let m', eventId, correlationId, causationId = mapCausation (context, m)
-            c, m', eventId, correlationId, causationId, t
+        let down struct (context, union) =
+            let struct (c, m, t) = down union
+            let struct (m', eventId, correlationId, causationId) = mapCausation struct (context, m)
+            struct (c, m', eventId, correlationId, causationId, t)
         Codec.Create(encoder, up = up, down = down, ?rejectNullaryCases = rejectNullaryCases)
 
     /// <summary>Generate an <code>IEventCodec</code> using the supplied <c>encoder</c>.<br/>
@@ -83,17 +84,17 @@ type Codec private () =
         (   encoder,
             // <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
             // to the representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
-            up : FsCodec.ITimelineEvent<'Body> * 'Contract -> 'Event,
+            up : struct (FsCodec.ITimelineEvent<'Body> * 'Contract) -> 'Event,
             // <summary>Maps a fresh <c>'Event</c> resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
             // The function is also expected to derive
             //   a <c>meta</c> object that will be serialized with the same options (if it's not <c>None</c>)
             //   and an Event Creation <c>timestamp</c>.</summary>
-            down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
+            down : 'Event -> struct ('Contract * 'Meta voption * DateTimeOffset voption),
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, 'Body, obj> =
 
-        let mapCausation (_context : obj, m : 'Meta option) = m, Guid.NewGuid(), null, null
+        let mapCausation struct (_context : obj voption, m : 'Meta voption) = struct (m, Guid.NewGuid(), null, null)
         Codec.Create(encoder, up = up, down = down, mapCausation = mapCausation, ?rejectNullaryCases = rejectNullaryCases)
 
     /// <summary>Generate an <code>IEventCodec</code> using the supplied <c>encoder</c>.<br/>
@@ -105,6 +106,6 @@ type Codec private () =
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Union, 'Body, obj> =
 
-        let up : FsCodec.ITimelineEvent<'Body> * 'Union -> 'Union = snd
-        let down (event : 'Union) = event, None, None
+        let up struct (_e : FsCodec.ITimelineEvent<'Body>, u : 'Union) : 'Union = u
+        let down (event : 'Union) = struct (event, ValueNone, ValueNone)
         Codec.Create(encoder, up = up, down = down, ?rejectNullaryCases = rejectNullaryCases)

--- a/src/FsCodec.Box/CoreCodec.fs
+++ b/src/FsCodec.Box/CoreCodec.fs
@@ -22,7 +22,7 @@ type Codec private () =
             // <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c><br/>
             // The function is also expected to derive an optional <c>meta</c> object that will be serialized with the same <c>encoder</c>,
             // and <c>eventId</c>, <c>correlationId</c>, <c>causationId</c> and an Event Creation<c>timestamp</c></summary>.
-            down : struct ('Context voption * 'Event) -> struct ('Contract * 'Meta voption * Guid * string * string * DateTimeOffset voption),
+            down : struct ('Context * 'Event) -> struct ('Contract * 'Meta voption * Guid * string * string * DateTimeOffset voption),
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, 'Body, 'Context> =
@@ -64,7 +64,7 @@ type Codec private () =
             //   and an Event Creation <c>timestamp</c>.</summary>
             down : 'Event -> struct ('Contract * 'Meta voption * DateTimeOffset voption),
             // <summary>Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>eventId</c> c) the <c>correlationId</c> and d) the <c>causationId</c></summary>
-            mapCausation : struct ('Context voption * 'Meta voption) -> struct ('Meta voption * Guid * string * string),
+            mapCausation : struct ('Context * 'Meta voption) -> struct ('Meta voption * Guid * string * string),
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
         : FsCodec.IEventCodec<'Event, 'Body, 'Context> =
@@ -92,9 +92,9 @@ type Codec private () =
             down : 'Event -> struct ('Contract * 'Meta voption * DateTimeOffset voption),
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
-        : FsCodec.IEventCodec<'Event, 'Body, obj> =
+        : FsCodec.IEventCodec<'Event, 'Body, unit> =
 
-        let mapCausation struct (_context : obj voption, m : 'Meta voption) = struct (m, Guid.NewGuid(), null, null)
+        let mapCausation struct ((), m : 'Meta voption) = struct (m, Guid.NewGuid(), null, null)
         Codec.Create(encoder, up = up, down = down, mapCausation = mapCausation, ?rejectNullaryCases = rejectNullaryCases)
 
     /// <summary>Generate an <code>IEventCodec</code> using the supplied <c>encoder</c>.<br/>
@@ -104,7 +104,7 @@ type Codec private () =
         (   encoder : TypeShape.UnionContract.IEncoder<'Body>,
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
-        : FsCodec.IEventCodec<'Union, 'Body, obj> =
+        : FsCodec.IEventCodec<'Union, 'Body, unit> =
 
         let up struct (_e : FsCodec.ITimelineEvent<'Body>, u : 'Union) : 'Union = u
         let down (event : 'Union) = struct (event, ValueNone, ValueNone)

--- a/src/FsCodec.Box/CoreCodec.fs
+++ b/src/FsCodec.Box/CoreCodec.fs
@@ -44,8 +44,8 @@ type Codec private () =
 
             member _.TryDecode encoded =
                 match dataCodec.TryDecode { CaseName = encoded.EventType; Payload = encoded.Data } with
-                | None -> None
-                | Some contract -> up (encoded, contract) |> Some }
+                | None -> ValueNone
+                | Some contract -> up (encoded, contract) |> ValueSome }
 
     /// <summary>Generate an <c>IEventCodec</c> using the supplied <c>encoder</c>.<br/>
     /// Uses <c>up</c>, <c>down</c> and <c>mapCausation</c> functions to facilitate upconversion/downconversion and eventId/correlationId/causationId/timestamp mapping

--- a/src/FsCodec.NewtonsoftJson/Codec.fs
+++ b/src/FsCodec.NewtonsoftJson/Codec.fs
@@ -74,7 +74,7 @@ type Codec private () =
             // <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c><br/>
             // The function is also expected to derive an optional <c>meta</c> object that will be serialized with the same <c>encoder</c>,
             // and <c>eventId</c>, <c>correlationId</c>, <c>causationId</c> and an Event Creation<c>timestamp</c></summary>.
-            down : struct ('Context voption * 'Event) -> struct ('Contract * 'Meta voption * Guid * string * string * DateTimeOffset voption),
+            down : struct ('Context * 'Event) -> struct ('Contract * 'Meta voption * Guid * string * string * DateTimeOffset voption),
             // <summary>Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c></summary>
             [<Optional; DefaultParameterValue(null)>] ?options,
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
@@ -97,7 +97,7 @@ type Codec private () =
             //   and an Event Creation <c>timestamp</c>.</summary>
             down : 'Event -> struct ('Contract * 'Meta voption * DateTimeOffset voption),
             // <summary>Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>eventId</c> c) the <c>correlationId</c> and d) the <c>causationId</c></summary>
-            mapCausation : struct ('Context voption * 'Meta voption) -> struct ('Meta voption * Guid * string * string),
+            mapCausation : struct ('Context * 'Meta voption) -> struct ('Meta voption * Guid * string * string),
             // <summary>Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c></summary>
             [<Optional; DefaultParameterValue(null)>] ?options,
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>

--- a/src/FsCodec.NewtonsoftJson/Codec.fs
+++ b/src/FsCodec.NewtonsoftJson/Codec.fs
@@ -70,11 +70,11 @@ type Codec private () =
     static member Create<'Event, 'Contract, 'Meta, 'Context when 'Contract :> TypeShape.UnionContract.IUnionContract>
         (   // <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
             // to the <c>'Event</c> representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
-            up : FsCodec.ITimelineEvent<ReadOnlyMemory<byte>> * 'Contract -> 'Event,
+            up : struct (FsCodec.ITimelineEvent<ReadOnlyMemory<byte>> * 'Contract) -> 'Event,
             // <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c><br/>
             // The function is also expected to derive an optional <c>meta</c> object that will be serialized with the same <c>encoder</c>,
             // and <c>eventId</c>, <c>correlationId</c>, <c>causationId</c> and an Event Creation<c>timestamp</c></summary>.
-            down : 'Context option * 'Event -> 'Contract * 'Meta option * Guid * string * string * DateTimeOffset option,
+            down : struct ('Context voption * 'Event) -> struct ('Contract * 'Meta voption * Guid * string * string * DateTimeOffset voption),
             // <summary>Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c></summary>
             [<Optional; DefaultParameterValue(null)>] ?options,
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
@@ -90,14 +90,14 @@ type Codec private () =
     static member Create<'Event, 'Contract, 'Meta, 'Context when 'Contract :> TypeShape.UnionContract.IUnionContract>
         (   // <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
             // to the representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
-            up : FsCodec.ITimelineEvent<ReadOnlyMemory<byte>> * 'Contract -> 'Event,
+            up : struct (FsCodec.ITimelineEvent<ReadOnlyMemory<byte>> * 'Contract) -> 'Event,
             // <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
             // The function is also expected to derive
             //   a <c>meta</c> object that will be serialized with the same options (if it's not <c>None</c>)
             //   and an Event Creation <c>timestamp</c>.</summary>
-            down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
+            down : 'Event -> struct ('Contract * 'Meta voption * DateTimeOffset voption),
             // <summary>Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>eventId</c> c) the <c>correlationId</c> and d) the <c>causationId</c></summary>
-            mapCausation : 'Context option * 'Meta option -> 'Meta option * Guid * string * string,
+            mapCausation : struct ('Context voption * 'Meta voption) -> struct ('Meta voption * Guid * string * string),
             // <summary>Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c></summary>
             [<Optional; DefaultParameterValue(null)>] ?options,
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
@@ -113,12 +113,12 @@ type Codec private () =
     static member Create<'Event, 'Contract, 'Meta when 'Contract :> TypeShape.UnionContract.IUnionContract>
         (   // <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
             // to the representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
-            up : FsCodec.ITimelineEvent<ReadOnlyMemory<byte>> * 'Contract -> 'Event,
+            up : struct (FsCodec.ITimelineEvent<ReadOnlyMemory<byte>> * 'Contract) -> 'Event,
             // <summary>Maps a fresh <c>'Event</c> resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
             // The function is also expected to derive
             //   a <c>meta</c> object that will be serialized with the same options (if it's not <c>None</c>)
             //   and an Event Creation <c>timestamp</c>.</summary>
-            down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
+            down : 'Event -> struct ('Contract * 'Meta voption * DateTimeOffset voption),
             // <summary>Configuration to be used by the underlying <c>Newtonsoft.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c></summary>
             [<Optional; DefaultParameterValue(null)>] ?options,
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>

--- a/src/FsCodec.NewtonsoftJson/Codec.fs
+++ b/src/FsCodec.NewtonsoftJson/Codec.fs
@@ -123,7 +123,7 @@ type Codec private () =
             [<Optional; DefaultParameterValue(null)>] ?options,
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
-        : FsCodec.IEventCodec<'Event, ReadOnlyMemory<byte>, obj> =
+        : FsCodec.IEventCodec<'Event, ReadOnlyMemory<byte>, unit> =
         FsCodec.Core.Codec.Create(mkEncoder options, up, down, ?rejectNullaryCases = rejectNullaryCases)
 
     /// <summary>Generate an <c>IEventCodec</c> that handles <c>ReadOnlyMemory&lt;byte&gt;</c> Event Bodies using the supplied <c>Newtonsoft.Json.JsonSerializerSettings</c> <c>options</c>.<br/>
@@ -134,5 +134,5 @@ type Codec private () =
             [<Optional; DefaultParameterValue(null)>] ?options,
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
-        : FsCodec.IEventCodec<'Union, ReadOnlyMemory<byte>, obj> =
+        : FsCodec.IEventCodec<'Union, ReadOnlyMemory<byte>, unit> =
         FsCodec.Core.Codec.Create(mkEncoder options, ?rejectNullaryCases = rejectNullaryCases)

--- a/src/FsCodec.SystemTextJson/Codec.fs
+++ b/src/FsCodec.SystemTextJson/Codec.fs
@@ -93,7 +93,7 @@ type Codec private () =
             [<Optional; DefaultParameterValue(null)>] ?options,
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
-        : FsCodec.IEventCodec<'Event, ReadOnlyMemory<byte>, obj> =
+        : FsCodec.IEventCodec<'Event, ReadOnlyMemory<byte>, unit> =
         FsCodec.Core.Codec.Create(mkEncoder options, up, down, ?rejectNullaryCases = rejectNullaryCases)
 
     /// <summary>Generate an <c>IEventCodec</c> that handles <c>ReadOnlyMemory&lt;byte&gt;</c> Event Bodies using the supplied <c>System.Text.Json</c> <c>options</c>.<br/>
@@ -104,5 +104,5 @@ type Codec private () =
             [<Optional; DefaultParameterValue(null)>] ?options,
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
-        : FsCodec.IEventCodec<'Union, ReadOnlyMemory<byte>, obj> =
+        : FsCodec.IEventCodec<'Union, ReadOnlyMemory<byte>, unit> =
         FsCodec.Core.Codec.Create(mkEncoder options, ?rejectNullaryCases = rejectNullaryCases)

--- a/src/FsCodec.SystemTextJson/Codec.fs
+++ b/src/FsCodec.SystemTextJson/Codec.fs
@@ -40,11 +40,11 @@ type Codec private () =
     static member Create<'Event, 'Contract, 'Meta, 'Context when 'Contract :> TypeShape.UnionContract.IUnionContract>
         (   // <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
             // to the <c>'Event</c> representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
-            up : FsCodec.ITimelineEvent<ReadOnlyMemory<byte>> * 'Contract -> 'Event,
+            up : struct (FsCodec.ITimelineEvent<ReadOnlyMemory<byte>> * 'Contract) -> 'Event,
             // <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c><br/>
             // The function is also expected to derive an optional <c>meta</c> object that will be serialized with the same <c>encoder</c>,
             // and <c>eventId</c>, <c>correlationId</c>, <c>causationId</c> and an Event Creation<c>timestamp</c></summary>.
-            down : 'Context option * 'Event -> 'Contract * 'Meta option * Guid * string * string * DateTimeOffset option,
+            down : struct ('Context voption * 'Event) -> struct ('Contract * 'Meta voption * Guid * string * string * DateTimeOffset voption),
             // <summary>Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c></summary>
             [<Optional; DefaultParameterValue(null)>] ?options,
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
@@ -60,14 +60,14 @@ type Codec private () =
     static member Create<'Event, 'Contract, 'Meta, 'Context when 'Contract :> TypeShape.UnionContract.IUnionContract>
         (   // <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
             // to the representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
-            up : FsCodec.ITimelineEvent<ReadOnlyMemory<byte>> * 'Contract -> 'Event,
+            up : struct (FsCodec.ITimelineEvent<ReadOnlyMemory<byte>> * 'Contract) -> 'Event,
             // <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
             // The function is also expected to derive
             //   a <c>meta</c> object that will be serialized with the same options (if it's not <c>None</c>)
             //   and an Event Creation <c>timestamp</c>.</summary>
-            down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
+            down : 'Event -> struct ('Contract * 'Meta voption * DateTimeOffset voption),
             // <summary>Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>eventId</c> c) the <c>correlationId</c> and d) the <c>causationId</c></summary>
-            mapCausation : 'Context option * 'Meta option -> 'Meta option * Guid * string * string,
+            mapCausation : struct ('Context voption * 'Meta voption) -> struct ('Meta voption * Guid * string * string),
             // <summary>Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c>.</summary>
             [<Optional; DefaultParameterValue(null)>] ?options,
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
@@ -83,12 +83,12 @@ type Codec private () =
     static member Create<'Event, 'Contract, 'Meta when 'Contract :> TypeShape.UnionContract.IUnionContract>
         (   // <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
             // to the representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
-            up : FsCodec.ITimelineEvent<ReadOnlyMemory<byte>> * 'Contract -> 'Event,
+            up : struct (FsCodec.ITimelineEvent<ReadOnlyMemory<byte>> * 'Contract) -> 'Event,
             // <summary>Maps a fresh <c>'Event</c> resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
             // The function is also expected to derive
             //   a <c>meta</c> object that will be serialized with the same options (if it's not <c>None</c>)
             //   and an Event Creation <c>timestamp</c>.</summary>
-            down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
+            down : 'Event -> struct ('Contract * 'Meta voption * DateTimeOffset voption),
             // <summary>Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c>.</summary>
             [<Optional; DefaultParameterValue(null)>] ?options,
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>

--- a/src/FsCodec.SystemTextJson/Codec.fs
+++ b/src/FsCodec.SystemTextJson/Codec.fs
@@ -44,7 +44,7 @@ type Codec private () =
             // <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c><br/>
             // The function is also expected to derive an optional <c>meta</c> object that will be serialized with the same <c>encoder</c>,
             // and <c>eventId</c>, <c>correlationId</c>, <c>causationId</c> and an Event Creation<c>timestamp</c></summary>.
-            down : struct ('Context voption * 'Event) -> struct ('Contract * 'Meta voption * Guid * string * string * DateTimeOffset voption),
+            down : struct ('Context * 'Event) -> struct ('Contract * 'Meta voption * Guid * string * string * DateTimeOffset voption),
             // <summary>Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c></summary>
             [<Optional; DefaultParameterValue(null)>] ?options,
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
@@ -67,7 +67,7 @@ type Codec private () =
             //   and an Event Creation <c>timestamp</c>.</summary>
             down : 'Event -> struct ('Contract * 'Meta voption * DateTimeOffset voption),
             // <summary>Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>eventId</c> c) the <c>correlationId</c> and d) the <c>causationId</c></summary>
-            mapCausation : struct ('Context voption * 'Meta voption) -> struct ('Meta voption * Guid * string * string),
+            mapCausation : struct ('Context * 'Meta voption) -> struct ('Meta voption * Guid * string * string),
             // <summary>Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c>.</summary>
             [<Optional; DefaultParameterValue(null)>] ?options,
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>

--- a/src/FsCodec.SystemTextJson/CodecJsonElement.fs
+++ b/src/FsCodec.SystemTextJson/CodecJsonElement.fs
@@ -39,11 +39,11 @@ type CodecJsonElement private () =
     static member Create<'Event, 'Contract, 'Meta, 'Context when 'Contract :> TypeShape.UnionContract.IUnionContract>
         (   // <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
             // to the <c>'Event</c> representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
-            up : FsCodec.ITimelineEvent<JsonElement> * 'Contract -> 'Event,
+            up : struct (FsCodec.ITimelineEvent<JsonElement> * 'Contract) -> 'Event,
             // <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c><br/>
             // The function is also expected to derive an optional <c>meta</c> object that will be serialized with the same <c>encoder</c>,
             // and <c>eventId</c>, <c>correlationId</c>, <c>causationId</c> and an Event Creation<c>timestamp</c></summary>.
-            down : 'Context option * 'Event -> 'Contract * 'Meta option * Guid * string * string * DateTimeOffset option,
+            down : struct ('Context voption * 'Event) -> struct ('Contract * 'Meta voption * Guid * string * string * DateTimeOffset voption),
             // <summary>Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c></summary>
             [<Optional; DefaultParameterValue(null)>] ?options,
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
@@ -59,14 +59,14 @@ type CodecJsonElement private () =
     static member Create<'Event, 'Contract, 'Meta, 'Context when 'Contract :> TypeShape.UnionContract.IUnionContract>
         (   // <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
             // to the representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
-            up : FsCodec.ITimelineEvent<JsonElement> * 'Contract -> 'Event,
+            up : struct (FsCodec.ITimelineEvent<JsonElement> * 'Contract) -> 'Event,
             // <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
             // The function is also expected to derive
             //   a <c>meta</c> object that will be serialized with the same options (if it's not <c>None</c>)
             //   and an Event Creation <c>timestamp</c>.</summary>
-            down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
+            down : 'Event -> struct ('Contract * 'Meta voption * DateTimeOffset voption),
             // <summary>Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>eventId</c> c) the <c>correlationId</c> and d) the <c>causationId</c></summary>
-            mapCausation : 'Context option * 'Meta option -> 'Meta option * Guid * string * string,
+            mapCausation : struct ('Context voption * 'Meta voption) -> struct ('Meta voption * Guid * string * string),
             // <summary>Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c>.</summary>
             [<Optional; DefaultParameterValue(null)>] ?options,
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
@@ -82,12 +82,12 @@ type CodecJsonElement private () =
     static member Create<'Event, 'Contract, 'Meta when 'Contract :> TypeShape.UnionContract.IUnionContract>
         (   // <summary>Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
             // to the representation (typically a Discriminated Union) that is to be presented to the programming model.</summary>
-            up : FsCodec.ITimelineEvent<JsonElement> * 'Contract -> 'Event,
+            up : struct (FsCodec.ITimelineEvent<JsonElement> * 'Contract) -> 'Event,
             // <summary>Maps a fresh <c>'Event</c> resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c>
             // The function is also expected to derive
             //   a <c>meta</c> object that will be serialized with the same options (if it's not <c>None</c>)
             //   and an Event Creation <c>timestamp</c>.</summary>
-            down : 'Event -> 'Contract * 'Meta option * DateTimeOffset option,
+            down : 'Event -> struct ('Contract * 'Meta voption * DateTimeOffset voption),
             // <summary>Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c>.</summary>
             [<Optional; DefaultParameterValue(null)>] ?options,
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>

--- a/src/FsCodec.SystemTextJson/CodecJsonElement.fs
+++ b/src/FsCodec.SystemTextJson/CodecJsonElement.fs
@@ -43,7 +43,7 @@ type CodecJsonElement private () =
             // <summary>Maps a fresh Event resulting from a Decision in the Domain representation type down to the TypeShape <c>UnionConverter</c> <c>'Contract</c><br/>
             // The function is also expected to derive an optional <c>meta</c> object that will be serialized with the same <c>encoder</c>,
             // and <c>eventId</c>, <c>correlationId</c>, <c>causationId</c> and an Event Creation<c>timestamp</c></summary>.
-            down : struct ('Context voption * 'Event) -> struct ('Contract * 'Meta voption * Guid * string * string * DateTimeOffset voption),
+            down : struct ('Context * 'Event) -> struct ('Contract * 'Meta voption * Guid * string * string * DateTimeOffset voption),
             // <summary>Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c></summary>
             [<Optional; DefaultParameterValue(null)>] ?options,
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
@@ -66,7 +66,7 @@ type CodecJsonElement private () =
             //   and an Event Creation <c>timestamp</c>.</summary>
             down : 'Event -> struct ('Contract * 'Meta voption * DateTimeOffset voption),
             // <summary>Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>eventId</c> c) the <c>correlationId</c> and d) the <c>causationId</c></summary>
-            mapCausation : struct ('Context voption * 'Meta voption) -> struct ('Meta voption * Guid * string * string),
+            mapCausation : struct ('Context * 'Meta voption) -> struct ('Meta voption * Guid * string * string),
             // <summary>Configuration to be used by the underlying <c>System.Text.Json</c> Serializer when encoding/decoding. Defaults to same as <c>Options.Default</c>.</summary>
             [<Optional; DefaultParameterValue(null)>] ?options,
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>

--- a/src/FsCodec.SystemTextJson/CodecJsonElement.fs
+++ b/src/FsCodec.SystemTextJson/CodecJsonElement.fs
@@ -92,7 +92,7 @@ type CodecJsonElement private () =
             [<Optional; DefaultParameterValue(null)>] ?options,
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
-        : FsCodec.IEventCodec<'Event, JsonElement, obj> =
+        : FsCodec.IEventCodec<'Event, JsonElement, unit> =
         FsCodec.Core.Codec.Create(mkEncoder options, up, down, ?rejectNullaryCases = rejectNullaryCases)
 
     /// <summary>Generate an <code>IEventCodec</code> that handles <c>JsonElement</c> Event Bodies using the supplied <c>System.Text.Json</c> <c>options</c>.
@@ -103,5 +103,5 @@ type CodecJsonElement private () =
             [<Optional; DefaultParameterValue(null)>] ?options,
             // <summary>Enables one to fail encoder generation if union contains nullary cases. Defaults to <c>false</c>, i.e. permitting them.</summary>
             [<Optional; DefaultParameterValue(null)>] ?rejectNullaryCases)
-        : FsCodec.IEventCodec<'Union, JsonElement, obj> =
+        : FsCodec.IEventCodec<'Union, JsonElement, unit> =
         FsCodec.Core.Codec.Create(mkEncoder options, ?rejectNullaryCases = rejectNullaryCases)

--- a/src/FsCodec/Codec.fs
+++ b/src/FsCodec/Codec.fs
@@ -13,14 +13,14 @@ type Codec =
     static member private Create<'Event, 'Format, 'Context>
         (   // <summary>Maps an 'Event to: an Event Type Name, a pair of <c>'Format</c>'s representing the <c>Data</c> and <c>Meta</c> together with the
             // <c>eventId</c>, <c>correlationId</c>, <c>causationId</c> and <c>timestamp</c>.</summary>
-            encode : 'Context option * 'Event -> string * 'Format * 'Format * Guid * string * string * DateTimeOffset option,
+            encode : struct ('Context option * 'Event) -> struct (string * 'Format * 'Format * Guid * string * string * DateTimeOffset option),
             // <summary>Attempts to map from an Event's stored data to <c>Some 'Event</c>, or <c>None</c> if not mappable.</summary>
-            tryDecode : ITimelineEvent<'Format> -> 'Event option)
+            tryDecode : ITimelineEvent<'Format> -> 'Event voption)
         : IEventCodec<'Event, 'Format, 'Context> =
 
         { new IEventCodec<'Event, 'Format, 'Context> with
             member _.Encode(context, event) =
-                let eventType, data, metadata, eventId, correlationId, causationId, timestamp = encode (context, event)
+                let struct (eventType, data, metadata, eventId, correlationId, causationId, timestamp) = encode struct (context, event)
                 Core.EventData.Create(eventType, data, metadata, eventId, correlationId, causationId, ?timestamp = timestamp)
 
             member _.TryDecode encoded =
@@ -33,30 +33,30 @@ type Codec =
             // The function is also expected to derive
             //   a <c>meta</c> object that will be serialized with the same settings (if it's not <c>None</c>)
             //   and an Event Creation <c>timestamp</c>.
-            encode : 'Event -> string * 'Format * DateTimeOffset option,
+            encode : 'Event -> struct (string * 'Format * DateTimeOffset option),
             // Maps from the TypeShape <c>UnionConverter</c> <c>'Contract</c> case the Event has been mapped to (with the raw event data as context)
             // to the <c>'Event</c> representation (typically a Discriminated Union) that is to be presented to the programming model.
-            tryDecode : ITimelineEvent<'Format> -> 'Event option,
+            tryDecode : ITimelineEvent<'Format> -> 'Event voption,
             // Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>correlationId</c> and c) the correlationId
-            mapCausation : 'Context option * 'Event -> 'Format * Guid * string * string)
+            mapCausation : struct ('Context option * 'Event) -> struct ('Format * Guid * string * string))
         : IEventCodec<'Event, 'Format, 'Context> =
 
-        let encode (context, event) =
-            let et, d, t = encode event
-            let m, eventId, correlationId, causationId = mapCausation (context, event)
-            et, d, m, eventId, correlationId, causationId, t
+        let encode struct (context, event) =
+            let struct (et, d, t) = encode event
+            let struct (m, eventId, correlationId, causationId) = mapCausation (context, event)
+            struct (et, d, m, eventId, correlationId, causationId, t)
         Codec.Create(encode, tryDecode)
 
     /// Generate an <code>IEventCodec</code> using the supplied pair of <c>encode</c> and <c>tryDecode</code> functions.
     static member Create<'Event, 'Format>
         (   // Maps a <c>'Event</c> to an Event Type Name and a UTF-8 array representing the <c>Data</c>.
-            encode : 'Event -> string * 'Format,
+            encode : 'Event -> struct (string * 'Format),
             // Attempts to map an Event Type Name and a UTF-8 array <c>Data</c> to <c>Some 'Event</c> case, or <c>None</c> if not mappable.
-            tryDecode : string * 'Format -> 'Event option)
+            tryDecode : struct (string * 'Format) -> 'Event voption)
         : IEventCodec<'Event, 'Format, obj> =
 
-        let encode' (_context : obj, event) =
-            let (eventType, data : 'Format) = encode event
-            eventType, data, Unchecked.defaultof<'Format> (* metadata *), Guid.NewGuid() (* eventId *), null (* correlationId *), null (* causationId *), None (* timestamp *)
-        let tryDecode' (encoded : ITimelineEvent<'Format>) = tryDecode (encoded.EventType, encoded.Data)
+        let encode' struct (_context : obj option, event) =
+            let struct (eventType, data : 'Format) = encode event
+            struct (eventType, data, Unchecked.defaultof<'Format> (* metadata *), Guid.NewGuid() (* eventId *), null (* correlationId *), null (* causationId *), None (* timestamp *))
+        let tryDecode' (encoded : ITimelineEvent<'Format>) = tryDecode struct (encoded.EventType, encoded.Data)
         Codec.Create(encode', tryDecode')

--- a/src/FsCodec/Codec.fs
+++ b/src/FsCodec/Codec.fs
@@ -13,7 +13,7 @@ type Codec =
     static member private Create<'Event, 'Format, 'Context>
         (   // <summary>Maps an 'Event to: an Event Type Name, a pair of <c>'Format</c>'s representing the <c>Data</c> and <c>Meta</c> together with the
             // <c>eventId</c>, <c>correlationId</c>, <c>causationId</c> and <c>timestamp</c>.</summary>
-            encode : struct ('Context voption * 'Event) -> struct (string * 'Format * 'Format * Guid * string * string * DateTimeOffset voption),
+            encode : struct ('Context * 'Event) -> struct (string * 'Format * 'Format * Guid * string * string * DateTimeOffset voption),
             // <summary>Attempts to map from an Event's stored data to <c>Some 'Event</c>, or <c>None</c> if not mappable.</summary>
             tryDecode : ITimelineEvent<'Format> -> 'Event voption)
         : IEventCodec<'Event, 'Format, 'Context> =
@@ -39,7 +39,7 @@ type Codec =
             // to the <c>'Event</c> representation (typically a Discriminated Union) that is to be presented to the programming model.
             tryDecode : ITimelineEvent<'Format> -> 'Event voption,
             // Uses the 'Context passed to the Encode call and the 'Meta emitted by <c>down</c> to a) the final metadata b) the <c>correlationId</c> and c) the correlationId
-            mapCausation : struct ('Context voption * 'Event) -> struct ('Format * Guid * string * string))
+            mapCausation : struct ('Context * 'Event) -> struct ('Format * Guid * string * string))
         : IEventCodec<'Event, 'Format, 'Context> =
 
         let encode struct (context, event) =
@@ -56,7 +56,7 @@ type Codec =
             tryDecode : struct (string * 'Format) -> 'Event voption)
         : IEventCodec<'Event, 'Format, obj> =
 
-        let encode' struct (_context : obj voption, event) =
+        let encode' struct (_context, event) =
             let struct (eventType, data : 'Format) = encode event
             struct (eventType, data, Unchecked.defaultof<'Format> (* metadata *), Guid.NewGuid() (* eventId *), null (* correlationId *), null (* causationId *), ValueNone (* timestamp *))
         let tryDecode' (encoded : ITimelineEvent<'Format>) = tryDecode (encoded.EventType, encoded.Data)

--- a/src/FsCodec/Codec.fs
+++ b/src/FsCodec/Codec.fs
@@ -21,7 +21,7 @@ type Codec =
         { new IEventCodec<'Event, 'Format, 'Context> with
             member _.Encode(context, event) =
                 let struct (eventType, data, metadata, eventId, correlationId, causationId, timestamp) = encode struct (context, event)
-                let ts = match timestamp with ValueNone -> None | ValueSome x -> Some x
+                let ts = match timestamp with ValueSome x -> Some x | ValueNone -> None
                 Core.EventData.Create(eventType, data, metadata, eventId, correlationId, causationId, ?timestamp = ts)
 
             member _.TryDecode encoded =
@@ -59,5 +59,5 @@ type Codec =
         let encode' struct (_context : obj voption, event) =
             let struct (eventType, data : 'Format) = encode event
             struct (eventType, data, Unchecked.defaultof<'Format> (* metadata *), Guid.NewGuid() (* eventId *), null (* correlationId *), null (* causationId *), ValueNone (* timestamp *))
-        let tryDecode' (encoded : ITimelineEvent<'Format>) = tryDecode struct (encoded.EventType, encoded.Data)
+        let tryDecode' (encoded : ITimelineEvent<'Format>) = tryDecode (encoded.EventType, encoded.Data)
         Codec.Create(encode', tryDecode')

--- a/src/FsCodec/Codec.fs
+++ b/src/FsCodec/Codec.fs
@@ -54,7 +54,7 @@ type Codec =
             encode : 'Event -> struct (string * 'Format),
             // Attempts to map an Event Type Name and a UTF-8 array <c>Data</c> to <c>Some 'Event</c> case, or <c>None</c> if not mappable.
             tryDecode : struct (string * 'Format) -> 'Event voption)
-        : IEventCodec<'Event, 'Format, obj> =
+        : IEventCodec<'Event, 'Format, unit> =
 
         let encode' struct (_context, event) =
             let struct (eventType, data : 'Format) = encode event

--- a/src/FsCodec/FsCodec.fs
+++ b/src/FsCodec/FsCodec.fs
@@ -31,7 +31,7 @@ type ITimelineEvent<'Format> =
 /// <summary>Defines an Event Contract interpreter that Encodes and/or Decodes payloads representing the known/relevant set of <c>'Event</c>s borne by a stream Category</summary>
 type IEventCodec<'Event, 'Format, 'Context> =
     /// <summary>Encodes a <c>'Event</c> instance into a <c>'Format</c> representation</summary>
-    abstract Encode : context: 'Context option * value: 'Event -> IEventData<'Format>
+    abstract Encode : context: 'Context voption * value: 'Event -> IEventData<'Format>
     /// <summary>Decodes a formatted representation into a <c>'Event</c> instance. Returns <c>None</c> on undefined <c>EventType</c>s</summary>
     abstract TryDecode : encoded: ITimelineEvent<'Format> -> 'Event voption
 

--- a/src/FsCodec/FsCodec.fs
+++ b/src/FsCodec/FsCodec.fs
@@ -101,8 +101,8 @@ type TimelineEvent<'Format> private (index, eventType, data, meta, eventId, corr
         (x : ITimelineEvent<'Format>) : ITimelineEvent<'Mapped> =
             { new ITimelineEvent<'Mapped> with
                 member _.Index = x.Index
-                member _.Context = x.Context
                 member _.IsUnfold = x.IsUnfold
+                member _.Context = x.Context
                 member _.Size = x.Size
                 member _.EventType = x.EventType
                 member _.Data = f x.Data

--- a/src/FsCodec/StreamName.fs
+++ b/src/FsCodec/StreamName.fs
@@ -15,20 +15,30 @@ and [<Measure>] streamName
 /// 2. {category}-{id1}_{id2}_...{idN}
 module StreamName =
 
+    (* Validation helpers *)
+
+    /// Throws if a candidate category includes a '-', is null, or is empty
+    let inline validateCategory (rawCategory : string) =
+        if rawCategory |> System.String.IsNullOrEmpty then invalidArg "rawCategory" "may not be null or empty"
+        if rawCategory.IndexOf '-' <> -1 then invalidArg "rawCategory" "may not contain embedded '-' symbols"
+
+    /// Throws if a candidate id element includes a '_', is null, or is empty
+    let inline validateElement (rawElement : string) =
+        if rawElement |> System.String.IsNullOrEmpty then invalidArg "rawElement" "may not contain null or empty components"
+        if rawElement.IndexOf '_' <> -1 then invalidArg "rawElement" "may not contain embedded '_' symbols"
+
     (* Creators: Building from constituent parts
        Guards against malformed category, aggregateId and/or aggregateId elements with exceptions *)
 
     /// Generates AggregateId from name elements; elements are separated from each other by '_'
     let createAggregateId (elements : string seq) : string =
-        for x in elements do
-            if System.String.IsNullOrEmpty x then invalidArg "elements" "may not contain null or empty components"
-            if x.IndexOf '_' <> -1 then invalidArg "elements" "may not contain embedded '_' symbols"
+        for x in elements do validateElement x
         System.String.Join("_", elements)
 
     /// Recommended way to specify a stream identifier; a category identifier and an aggregate identity
     /// category is separated from id by `-`
     let createRaw struct (category : string, aggregateId : string) : string =
-        if category.IndexOf '-' <> -1 then invalidArg "category" "may not contain embedded '-' symbols"
+        validateCategory category
         System.String.Concat(category, "-", aggregateId)
 
     /// Recommended way to specify a stream identifier; a category identifier and an aggregate identity

--- a/src/FsCodec/StreamName.fs
+++ b/src/FsCodec/StreamName.fs
@@ -15,11 +15,15 @@ and [<Measure>] streamName
 /// 2. {category}-{id1}_{id2}_...{idN}
 module StreamName =
 
-    let private dash = [|'-'|] // Separates {category}-{aggregateId}
-    let private underscore = [|'_'|] // separates {category}-{subId1_subId2_subId3_..._subIdN}
-
     (* Creators: Building from constituent parts
-       Guards against malformed category, aggregateId and/or aggregateIdElements with exceptions *)
+       Guards against malformed category, aggregateId and/or aggregateId elements with exceptions *)
+
+    /// Generates AggregateId from name elements; elements are separated from each other by '_'
+    let createAggregateId (elements : string seq) : string =
+        for x in elements do
+            if System.String.IsNullOrEmpty x then invalidArg "elements" "may not contain null or empty components"
+            if x.IndexOf '_' <> -1 then invalidArg "elements" "may not contain embedded '_' symbols"
+        System.String.Join("_", elements)
 
     /// Recommended way to specify a stream identifier; a category identifier and an aggregate identity
     /// category is separated from id by `-`
@@ -32,13 +36,6 @@ module StreamName =
     let create (category : string) (aggregateId : string) : StreamName =
         createRaw (category, aggregateId) |> UMX.tag
 
-    /// Generates AggregateId from name elements; elements are separated from each other by '_'
-    let createAggregateId (elements : string seq) : string =
-        for x in elements do
-            if System.String.IsNullOrEmpty x then invalidArg "elements" "may not contain null or empty components"
-            if x.IndexOf '_' <> -1 then invalidArg "elements" "may not contain embedded '_' symbols"
-        System.String.Join("_", elements)
-
     /// Composes a StreamName from a category and > 1 name elements.
     /// category is separated from the aggregateId by '-'; elements are separated from each other by '_'
     let compose (category : string) (aggregateIdElements : string seq) : StreamName =
@@ -47,22 +44,24 @@ module StreamName =
     /// <summary>Validates and maps a trusted Stream Name consisting of a Category and an Id separated by a '-' (dash).<br/>
     /// Throws <c>InvalidArgumentException</c> if it does not adhere to that form.</summary>
     let parse (rawStreamName : string) : StreamName =
-        if rawStreamName.IndexOf('-') = -1 then
+        if rawStreamName.IndexOf '-' = -1 then
             invalidArg "rawStreamName" (sprintf "Stream Name '%s' must contain a '-' separator" rawStreamName)
         UMX.tag rawStreamName
 
     (* Parsing: Raw Stream name Validation functions/pattern that handle malformed cases without throwing *)
 
-    /// <summary>Attempts to split a Stream Name in the form <c>{category}-{id}</c> into its two elements.
-    /// The <c>{id}</c> segment is permitted to include embedded '-' (dash) characters
+    let private dash = [|'-'|] // Separates {category}-{aggregateId}
+
+    /// <summary>Attempts to split a Stream Name in the form <c>{category}-{aggregateId}</c> into its two elements.
+    /// The <c>{aggregateId}</c> segment is permitted to include embedded '-' (dash) characters
     /// Returns <c>None</c> if it does not adhere to that form.</summary>
     let trySplitCategoryAndId (rawStreamName : string) : struct (string * string) voption =
         match rawStreamName.Split(dash, 2) with
         | [| cat; id |] -> ValueSome struct (cat, id)
         | _ -> ValueNone
 
-    /// <summary>Attempts to split a Stream Name in the form <c>{category}-{id}</c> into its two elements.
-    /// The <c>{id}</c> segment is permitted to include embedded '-' (dash) characters
+    /// <summary>Attempts to split a Stream Name in the form <c>{category}-{aggregateId}</c> into its two elements.
+    /// The <c>{aggregateId}</c> segment is permitted to include embedded '-' (dash) characters
     /// Yields <c>NotCategorized</c> if it does not adhere to that form.</summary>
     let (|Categorized|NotCategorized|) (rawStreamName : string) : Choice<struct (string * string), unit> =
         match trySplitCategoryAndId rawStreamName with
@@ -78,7 +77,7 @@ module StreamName =
     (* Splitting: functions/Active patterns for (i.e. generated via `parse`, `create` or `compose`) well-formed Stream Names
        Will throw if presented with malformed strings [generated via alternate means] *)
 
-    /// <summary>Splits a well-formed Stream Name of the form <c>{category}-{id}</c> into its two elements.<br/>
+    /// <summary>Splits a well-formed Stream Name of the form <c>{category}-{aggregateId}</c> into its two elements.<br/>
     /// Throws <c>InvalidArgumentException</c> if it does not adhere to the well known format (i.e. if it was not produced by `parse`).</summary>
     /// <remarks>Inverse of <c>create</c></remarks>
     let splitCategoryAndId (streamName : StreamName) : struct (string * string) =
@@ -87,26 +86,28 @@ module StreamName =
         | ValueSome catAndId -> catAndId
         | ValueNone -> invalidArg "streamName" (sprintf "Stream Name '%s' must contain a '-' separator" rawName)
 
-    /// <summary>Splits a well-formed Stream Name of the form <c>{category}-{id}</c> into its two elements.<br/>
+    /// <summary>Splits a well-formed Stream Name of the form <c>{category}-{aggregateId}</c> into its two elements.<br/>
     /// Throws <c>InvalidArgumentException</c> if the stream name is not well-formed.</summary>
     /// <remarks>Inverse of <c>create</c></remarks>
     let (|CategoryAndId|) : StreamName -> struct (string * string) = splitCategoryAndId
 
+    let private underscore = [|'_'|] // separates {category}-{subId1_subId2_subId3_..._subIdN}
+
     /// <summary>Splits a `_`-separated set of id elements (as formed by `compose`) into its (one or more) constituent elements.</summary>
     /// <remarks>Inverse of what <code>compose</code> does to the subElements</remarks>
-    let (|IdElements|) (aggregateId : string) : string[] =
+    let (|IdElements|) (aggregateId : string) : string array =
         aggregateId.Split underscore
 
     /// <summary>Splits a well-formed Stream Name of the form {category}-{id1}_{id2}_{idN} into a pair of category and ids.<br/>
     /// Throws <c>InvalidArgumentException</c> if it does not adhere to the well known format (i.e. if it was not produced by `parse`).</summary>
     /// <remarks>Inverse of <c>create</c></remarks>
-    let splitCategoryAndIds (streamName : StreamName) : struct (string * string[]) =
+    let splitCategoryAndIds (streamName : StreamName) : struct (string * string array) =
         let rawName = toString streamName
         match trySplitCategoryAndId rawName with
         | ValueSome (cat, IdElements ids) -> (cat, ids)
-        | ValueNone -> invalidArg "streamName" (sprintf "Stream Name '%s' did not contain exactly one '-' separator" rawName)
+        | ValueNone -> invalidArg "streamName" (sprintf "Stream Name '%s' must contain a '-' separator" rawName)
 
-    /// <summary>Splits a well-formed Stream Name of the form <c>{category}-{id}</c> into the two elements.<br/>
+    /// <summary>Splits a well-formed Stream Name of the form <c>{category}-{aggregateId}</c> into the two elements.<br/>
     /// Throws <c>InvalidArgumentException</c> if the stream name is not well-formed</summary>
     /// <remarks>Inverse of <c>create</c></remarks>
-    let (|CategoryAndIds|) : StreamName -> struct (string * string[]) = splitCategoryAndIds
+    let (|CategoryAndIds|) : StreamName -> struct (string * string array) = splitCategoryAndIds

--- a/src/FsCodec/StreamName.fs
+++ b/src/FsCodec/StreamName.fs
@@ -23,22 +23,17 @@ module StreamName =
 
     /// Recommended way to specify a stream identifier; a category identifier and an aggregate identity
     /// category is separated from id by `-`
-    let create (category : string) aggregateId : StreamName =
+    let create (category : string) (aggregateId : string) : StreamName =
         if category.IndexOf '-' <> -1 then invalidArg "category" "may not contain embedded '-' symbols"
-        UMX.tag (sprintf "%s-%s" category aggregateId)
+        UMX.tag (System.String.Concat(category, "-", aggregateId))
 
     /// Composes a StreamName from a category and > 1 name elements.
     /// category is separated from the aggregateId by '-'; elements are separated from each other by '_'
     let compose (category : string) (aggregateIdElements : string seq) : StreamName =
-        let buf = System.Text.StringBuilder 128
-        let mutable first = true
         for x in aggregateIdElements do
-            if first then () else buf.Append '_' |> ignore
-            first <- false
             if System.String.IsNullOrEmpty x then invalidArg "subElements" "may not contain null or empty components"
             if x.IndexOf '_' <> -1 then invalidArg "subElements" "may not contain embedded '_' symbols"
-            buf.Append x |> ignore
-        create category (buf.ToString())
+        create category (System.String.Join("_", aggregateIdElements))
 
     /// <summary>Validates and maps a trusted Stream Name consisting of a Category and an Id separated by a '-' (dash).<br/>
     /// Throws <c>InvalidArgumentException</c> if it does not adhere to that form.</summary>
@@ -52,18 +47,18 @@ module StreamName =
     /// <summary>Attempts to split a Stream Name in the form <c>{category}-{id}</c> into its two elements.
     /// The <c>{id}</c> segment is permitted to include embedded '-' (dash) characters
     /// Returns <c>None</c> if it does not adhere to that form.</summary>
-    let trySplitCategoryAndId (rawStreamName : string) : (string * string) option =
+    let trySplitCategoryAndId (rawStreamName : string) : struct (string * string) voption =
         match rawStreamName.Split(dash, 2) with
-        | [| cat; id |] -> Some (cat, id)
-        | _ -> None
+        | [| cat; id |] -> ValueSome struct (cat, id)
+        | _ -> ValueNone
 
     /// <summary>Attempts to split a Stream Name in the form <c>{category}-{id}</c> into its two elements.
     /// The <c>{id}</c> segment is permitted to include embedded '-' (dash) characters
     /// Yields <c>NotCategorized</c> if it does not adhere to that form.</summary>
-    let (|Categorized|NotCategorized|) (rawStreamName : string) : Choice<string * string, unit> =
+    let (|Categorized|NotCategorized|) (rawStreamName : string) : Choice<struct (string * string), unit> =
         match trySplitCategoryAndId rawStreamName with
-        | Some catAndId -> Categorized catAndId
-        | None -> NotCategorized
+        | ValueSome catAndId -> Categorized catAndId
+        | ValueNone -> NotCategorized
 
     (* Rendering *)
 
@@ -77,16 +72,16 @@ module StreamName =
     /// <summary>Splits a well-formed Stream Name of the form <c>{category}-{id}</c> into its two elements.<br/>
     /// Throws <c>InvalidArgumentException</c> if it does not adhere to the well known format (i.e. if it was not produced by `parse`).</summary>
     /// <remarks>Inverse of <c>create</c></remarks>
-    let splitCategoryAndId (streamName : StreamName) : string * string =
+    let splitCategoryAndId (streamName : StreamName) : struct (string * string) =
         let rawName = toString streamName
         match trySplitCategoryAndId rawName with
-        | Some catAndId -> catAndId
-        | None -> invalidArg (sprintf "Stream Name '%s' must contain a '-' separator" rawName) "streamName"
+        | ValueSome catAndId -> catAndId
+        | ValueNone -> invalidArg (sprintf "Stream Name '%s' must contain a '-' separator" rawName) "streamName"
 
     /// <summary>Splits a well-formed Stream Name of the form <c>{category}-{id}</c> into its two elements.<br/>
     /// Throws <c>InvalidArgumentException</c> if the stream name is not well-formed.</summary>
     /// <remarks>Inverse of <c>create</c></remarks>
-    let (|CategoryAndId|) : StreamName -> (string * string) = splitCategoryAndId
+    let (|CategoryAndId|) : StreamName -> struct (string * string) = splitCategoryAndId
 
     /// <summary>Splits a `_`-separated set of id elements (as formed by `compose`) into its (one or more) constituent elements.</summary>
     /// <remarks>Inverse of what <code>compose</code> does to the subElements</remarks>
@@ -96,13 +91,13 @@ module StreamName =
     /// <summary>Splits a well-formed Stream Name of the form {category}-{id1}_{id2}_{idN} into a pair of category and ids.<br/>
     /// Throws <c>InvalidArgumentException</c> if it does not adhere to the well known format (i.e. if it was not produced by `parse`).</summary>
     /// <remarks>Inverse of <c>create</c></remarks>
-    let splitCategoryAndIds (streamName : StreamName) : string * string[] =
+    let splitCategoryAndIds (streamName : StreamName) : struct (string * string[]) =
         let rawName = toString streamName
         match trySplitCategoryAndId rawName with
-        | Some (cat, IdElements ids) -> (cat, ids)
-        | None -> invalidArg (sprintf "Stream Name '%s' did not contain exactly one '-' separator" rawName) "streamName"
+        | ValueSome (cat, IdElements ids) -> (cat, ids)
+        | ValueNone -> invalidArg (sprintf "Stream Name '%s' did not contain exactly one '-' separator" rawName) "streamName"
 
     /// <summary>Splits a well-formed Stream Name of the form <c>{category}-{id}</c> into the two elements.<br/>
     /// Throws <c>InvalidArgumentException</c> if the stream name is not well-formed</summary>
     /// <remarks>Inverse of <c>create</c></remarks>
-    let (|CategoryAndIds|) : StreamName -> (string * string[]) = splitCategoryAndIds
+    let (|CategoryAndIds|) : StreamName -> struct (string * string[]) = splitCategoryAndIds

--- a/tests/FsCodec.NewtonsoftJson.Tests/VerbatimUtf8ConverterTests.fs
+++ b/tests/FsCodec.NewtonsoftJson.Tests/VerbatimUtf8ConverterTests.fs
@@ -61,7 +61,7 @@ module VerbatimUtf8Tests = // not a module or CI will fail for net461
 
     let [<Fact>] ``encodes correctly`` () =
         let input = Union.A { embed = "\"" }
-        let encoded = eventCodec.Encode(None, input)
+        let encoded = eventCodec.Encode(ValueNone, input)
         let e : Batch = mkBatch encoded
         let res = JsonConvert.SerializeObject(e)
         test <@ res.Contains """"d":{"embed":"\""}""" @>
@@ -74,7 +74,7 @@ module VerbatimUtf8Tests = // not a module or CI will fail for net461
     let defaultEventCodec = Codec.Create<U>(defaultSettings)
 
     let [<Property>] ``round-trips diverse bodies correctly`` (x: U) =
-        let encoded = defaultEventCodec.Encode(None,x)
+        let encoded = defaultEventCodec.Encode(ValueNone, x)
         let e : Batch = mkBatch encoded
         let ser = JsonConvert.SerializeObject(e, defaultSettings)
         let des = JsonConvert.DeserializeObject<Batch>(ser, defaultSettings)
@@ -85,7 +85,7 @@ module VerbatimUtf8Tests = // not a module or CI will fail for net461
     // https://github.com/JamesNK/Newtonsoft.Json/issues/862 // doesnt apply to this case
     let [<Fact>] ``Codec does not fall prey to Date-strings being mutilated`` () =
         let x = ES { embed = "2016-03-31T07:02:00+07:00" }
-        let encoded = defaultEventCodec.Encode(None,x)
+        let encoded = defaultEventCodec.Encode(ValueNone, x)
         let adapted = FsCodec.Core.TimelineEvent.Create(-1L, encoded.EventType, encoded.Data, encoded.Meta, timestamp = encoded.Timestamp)
         let decoded = defaultEventCodec.TryDecode adapted |> ValueOption.get
         test <@ x = decoded @>

--- a/tests/FsCodec.NewtonsoftJson.Tests/VerbatimUtf8ConverterTests.fs
+++ b/tests/FsCodec.NewtonsoftJson.Tests/VerbatimUtf8ConverterTests.fs
@@ -67,7 +67,7 @@ module VerbatimUtf8Tests = // not a module or CI will fail for net461
         test <@ res.Contains """"d":{"embed":"\""}""" @>
         let des = JsonConvert.DeserializeObject<Batch>(res)
         let loaded = FsCodec.Core.TimelineEvent.Create(-1L, des.e[0].c, ReadOnlyMemory des.e[0].d)
-        let decoded = eventCodec.TryDecode loaded |> Option.get
+        let decoded = eventCodec.TryDecode loaded |> ValueOption.get
         input =! decoded
 
     let defaultSettings = Options.CreateDefault()
@@ -79,7 +79,7 @@ module VerbatimUtf8Tests = // not a module or CI will fail for net461
         let ser = JsonConvert.SerializeObject(e, defaultSettings)
         let des = JsonConvert.DeserializeObject<Batch>(ser, defaultSettings)
         let loaded = FsCodec.Core.TimelineEvent.Create(-1L, des.e[0].c, ReadOnlyMemory des.e[0].d)
-        let decoded = defaultEventCodec.TryDecode loaded |> Option.get
+        let decoded = defaultEventCodec.TryDecode loaded |> ValueOption.get
         x =! decoded
 
     // https://github.com/JamesNK/Newtonsoft.Json/issues/862 // doesnt apply to this case
@@ -87,7 +87,7 @@ module VerbatimUtf8Tests = // not a module or CI will fail for net461
         let x = ES { embed = "2016-03-31T07:02:00+07:00" }
         let encoded = defaultEventCodec.Encode(None,x)
         let adapted = FsCodec.Core.TimelineEvent.Create(-1L, encoded.EventType, encoded.Data, encoded.Meta, timestamp = encoded.Timestamp)
-        let decoded = defaultEventCodec.TryDecode adapted |> Option.get
+        let decoded = defaultEventCodec.TryDecode adapted |> ValueOption.get
         test <@ x = decoded @>
 
     //// NB while this aspect works, we don't support it as it gets messy when you then use the VerbatimUtf8Converter

--- a/tests/FsCodec.NewtonsoftJson.Tests/VerbatimUtf8ConverterTests.fs
+++ b/tests/FsCodec.NewtonsoftJson.Tests/VerbatimUtf8ConverterTests.fs
@@ -61,7 +61,7 @@ module VerbatimUtf8Tests = // not a module or CI will fail for net461
 
     let [<Fact>] ``encodes correctly`` () =
         let input = Union.A { embed = "\"" }
-        let encoded = eventCodec.Encode(ValueNone, input)
+        let encoded = eventCodec.Encode((), input)
         let e : Batch = mkBatch encoded
         let res = JsonConvert.SerializeObject(e)
         test <@ res.Contains """"d":{"embed":"\""}""" @>
@@ -74,7 +74,7 @@ module VerbatimUtf8Tests = // not a module or CI will fail for net461
     let defaultEventCodec = Codec.Create<U>(defaultSettings)
 
     let [<Property>] ``round-trips diverse bodies correctly`` (x: U) =
-        let encoded = defaultEventCodec.Encode(ValueNone, x)
+        let encoded = defaultEventCodec.Encode((), x)
         let e : Batch = mkBatch encoded
         let ser = JsonConvert.SerializeObject(e, defaultSettings)
         let des = JsonConvert.DeserializeObject<Batch>(ser, defaultSettings)
@@ -85,7 +85,7 @@ module VerbatimUtf8Tests = // not a module or CI will fail for net461
     // https://github.com/JamesNK/Newtonsoft.Json/issues/862 // doesnt apply to this case
     let [<Fact>] ``Codec does not fall prey to Date-strings being mutilated`` () =
         let x = ES { embed = "2016-03-31T07:02:00+07:00" }
-        let encoded = defaultEventCodec.Encode(ValueNone, x)
+        let encoded = defaultEventCodec.Encode((), x)
         let adapted = FsCodec.Core.TimelineEvent.Create(-1L, encoded.EventType, encoded.Data, encoded.Meta, timestamp = encoded.Timestamp)
         let decoded = defaultEventCodec.TryDecode adapted |> ValueOption.get
         test <@ x = decoded @>

--- a/tests/FsCodec.SystemTextJson.Tests/CodecTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/CodecTests.fs
@@ -57,7 +57,7 @@ let [<Property>] roundtrips value =
 
     let des = serdes.Deserialize<Envelope> ser
     let wrapped = FsCodec.Core.TimelineEvent<JsonElement>.Create(-1L, eventType, des.d)
-    let decoded = eventCodec.TryDecode wrapped |> Option.get
+    let decoded = eventCodec.TryDecode wrapped |> ValueOption.get
 
     let expected =
         match value with
@@ -67,5 +67,5 @@ let [<Property>] roundtrips value =
     test <@ expected = decoded @>
 
     // Also validate the adapters work when put in series (NewtonsoftJson tests are responsible for covering the individual hops)
-    let decodedMultiHop = multiHopCodec.TryDecode wrapped |> Option.get
+    let decodedMultiHop = multiHopCodec.TryDecode wrapped |> ValueOption.get
     test <@ expected = decodedMultiHop @>

--- a/tests/FsCodec.SystemTextJson.Tests/InteropTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/InteropTests.fs
@@ -14,7 +14,7 @@ let mkBatch = FsCodec.NewtonsoftJson.Tests.VerbatimUtf8ConverterTests.mkBatch
 let indirectCodec = FsCodec.SystemTextJson.CodecJsonElement.Create() |> FsCodec.SystemTextJson.Interop.InteropHelpers.ToUtf8Codec
 let [<Fact>] ``encodes correctly`` () =
     let input = Union.A { embed = "\"" }
-    let encoded = indirectCodec.Encode(None, input)
+    let encoded = indirectCodec.Encode(ValueNone, input)
     let e : Batch = mkBatch encoded
     let res = JsonConvert.SerializeObject(e)
     test <@ res.Contains """"d":{"embed":"\""}""" @>
@@ -39,7 +39,7 @@ let indirectCodecU = FsCodec.SystemTextJson.CodecJsonElement.Create<U>() |> FsCo
 let [<Property>] ``round-trips diverse bodies correctly`` (x: U, encodeDirect, decodeDirect) =
     let encoder = if encodeDirect then defaultEventCodec else indirectCodecU
     let decoder = if decodeDirect then defaultEventCodec else indirectCodecU
-    let encoded = encoder.Encode(None,x)
+    let encoded = encoder.Encode(ValueNone, x)
     let e : Batch = mkBatch encoded
     let ser = JsonConvert.SerializeObject(e, defaultSettings)
     let des = JsonConvert.DeserializeObject<Batch>(ser, defaultSettings)

--- a/tests/FsCodec.SystemTextJson.Tests/InteropTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/InteropTests.fs
@@ -20,7 +20,7 @@ let [<Fact>] ``encodes correctly`` () =
     test <@ res.Contains """"d":{"embed":"\""}""" @>
     let des = JsonConvert.DeserializeObject<Batch>(res)
     let loaded = FsCodec.Core.TimelineEvent.Create(-1L, des.e[0].c, ReadOnlyMemory des.e[0].d)
-    let decoded = indirectCodec.TryDecode loaded |> Option.get
+    let decoded = indirectCodec.TryDecode loaded |> ValueOption.get
     input =! decoded
 
 type EmbeddedString = { embed : string }
@@ -44,5 +44,5 @@ let [<Property>] ``round-trips diverse bodies correctly`` (x: U, encodeDirect, d
     let ser = JsonConvert.SerializeObject(e, defaultSettings)
     let des = JsonConvert.DeserializeObject<Batch>(ser, defaultSettings)
     let loaded = FsCodec.Core.TimelineEvent.Create(-1L, des.e[0].c, ReadOnlyMemory des.e[0].d)
-    let decoded = decoder.TryDecode loaded |> Option.get
+    let decoded = decoder.TryDecode loaded |> ValueOption.get
     x =! decoded

--- a/tests/FsCodec.SystemTextJson.Tests/InteropTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/InteropTests.fs
@@ -14,7 +14,7 @@ let mkBatch = FsCodec.NewtonsoftJson.Tests.VerbatimUtf8ConverterTests.mkBatch
 let indirectCodec = FsCodec.SystemTextJson.CodecJsonElement.Create() |> FsCodec.SystemTextJson.Interop.InteropHelpers.ToUtf8Codec
 let [<Fact>] ``encodes correctly`` () =
     let input = Union.A { embed = "\"" }
-    let encoded = indirectCodec.Encode(ValueNone, input)
+    let encoded = indirectCodec.Encode((), input)
     let e : Batch = mkBatch encoded
     let res = JsonConvert.SerializeObject(e)
     test <@ res.Contains """"d":{"embed":"\""}""" @>
@@ -39,7 +39,7 @@ let indirectCodecU = FsCodec.SystemTextJson.CodecJsonElement.Create<U>() |> FsCo
 let [<Property>] ``round-trips diverse bodies correctly`` (x: U, encodeDirect, decodeDirect) =
     let encoder = if encodeDirect then defaultEventCodec else indirectCodecU
     let decoder = if decodeDirect then defaultEventCodec else indirectCodecU
-    let encoded = encoder.Encode(ValueNone, x)
+    let encoded = encoder.Encode((), x)
     let e : Batch = mkBatch encoded
     let ser = JsonConvert.SerializeObject(e, defaultSettings)
     let des = JsonConvert.DeserializeObject<Batch>(ser, defaultSettings)

--- a/tests/FsCodec.Tests/StreamNameTests.fs
+++ b/tests/FsCodec.Tests/StreamNameTests.fs
@@ -33,5 +33,5 @@ let [<Fact>] ``Can roundtrip single aggregateIds with embedded dashes and unders
 let [<Fact>] ``StreamName parse throws given 0 separators`` () =
     raisesWith <@ StreamName.parse "Cat" @> <|
         fun (e : System.ArgumentException) ->
-            <@  e.ParamName = "streamName"
+            <@  e.ParamName = "rawStreamName"
                 && e.Message.StartsWith "Stream Name 'Cat' must contain a '-' separator" @>

--- a/tests/FsCodec.Tests/TryDeflateTests.fs
+++ b/tests/FsCodec.Tests/TryDeflateTests.fs
@@ -5,7 +5,7 @@ open Swensen.Unquote
 open Xunit
 
 let inline roundtrip (sut : FsCodec.IEventCodec<_, _, _>) value =
-    let encoded = sut.Encode(context = None, value = value)
+    let encoded = sut.Encode(context = ValueNone, value = value)
     let loaded = FsCodec.Core.TimelineEvent.Create(-1L, encoded.EventType, encoded.Data)
     sut.TryDecode loaded
 
@@ -39,14 +39,14 @@ module TryDeflate =
         res' =! ValueSome compressibleValue
 
     let [<Fact>] ``compresses when possible`` () =
-        let encoded = sut.Encode(context = None, value = compressibleValue)
+        let encoded = sut.Encode(context = ValueNone, value = compressibleValue)
         let struct (encoding, encodedValue) = encoded.Data
         encodedValue.Length <! compressibleValue.Length
 
     let [<Fact>] ``uses raw value where compression not possible`` () =
         let value = "NotCompressible"
-        let directResult = StringUtf8.sut.Encode(None, value).Data
-        let encoded = sut.Encode(context = None, value = value)
+        let directResult = StringUtf8.sut.Encode(ValueNone, value).Data
+        let encoded = sut.Encode(context = ValueNone, value = value)
         let struct (_encoding, result) = encoded.Data
         true =! directResult.Span.SequenceEqual(result.Span)
 
@@ -62,7 +62,7 @@ module Uncompressed =
         res' =! ValueSome value
 
     let [<Fact>] ``does not compress, even if it was possible to`` () =
-        let directResult = StringUtf8.sut.Encode(None, value).Data
-        let encoded = sut.Encode(context = None, value = value)
+        let directResult = StringUtf8.sut.Encode(ValueNone, value).Data
+        let encoded = sut.Encode(context = ValueNone, value = value)
         let struct (_encoding, result) = encoded.Data
         true =! directResult.Span.SequenceEqual(result.Span)

--- a/tests/FsCodec.Tests/TryDeflateTests.fs
+++ b/tests/FsCodec.Tests/TryDeflateTests.fs
@@ -17,8 +17,8 @@ module StringUtf8 =
     let enc (s : string) : ReadOnlyMemory<byte> = System.Text.Encoding.UTF8.GetBytes s |> ReadOnlyMemory
     let dec (b : ReadOnlySpan<byte>) : string = System.Text.Encoding.UTF8.GetString b
     let stringUtf8Encoder =
-        let encode e = eventType, enc e
-        let tryDecode (s, b : ReadOnlyMemory<byte>) = if s = eventType then Some (dec b.Span) else invalidOp "Invalid eventType value"
+        let encode e = struct (eventType, enc e)
+        let tryDecode struct (s, b : ReadOnlyMemory<byte>) = if s = eventType then ValueSome (dec b.Span) else invalidOp "Invalid eventType value"
         FsCodec.Codec.Create(encode, tryDecode)
 
     let sut = stringUtf8Encoder
@@ -26,7 +26,7 @@ module StringUtf8 =
     let [<Fact>] roundtrips () =
         let value = "TestValue"
         let res' = roundtrip sut value
-        res' =! Some value
+        res' =! ValueSome value
 
 module TryDeflate =
 
@@ -36,7 +36,7 @@ module TryDeflate =
 
     let [<Fact>] roundtrips () =
         let res' = roundtrip sut compressibleValue
-        res' =! Some compressibleValue
+        res' =! ValueSome compressibleValue
 
     let [<Fact>] ``compresses when possible`` () =
         let encoded = sut.Encode(context = None, value = compressibleValue)
@@ -59,7 +59,7 @@ module Uncompressed =
 
     let [<Fact>] roundtrips () =
         let res' = roundtrip sut value
-        res' =! Some value
+        res' =! ValueSome value
 
     let [<Fact>] ``does not compress, even if it was possible to`` () =
         let directResult = StringUtf8.sut.Encode(None, value).Data

--- a/tests/FsCodec.Tests/TryDeflateTests.fs
+++ b/tests/FsCodec.Tests/TryDeflateTests.fs
@@ -5,7 +5,7 @@ open Swensen.Unquote
 open Xunit
 
 let inline roundtrip (sut : FsCodec.IEventCodec<_, _, _>) value =
-    let encoded = sut.Encode(context = ValueNone, value = value)
+    let encoded = sut.Encode(context = null, value = value)
     let loaded = FsCodec.Core.TimelineEvent.Create(-1L, encoded.EventType, encoded.Data)
     sut.TryDecode loaded
 

--- a/tests/FsCodec.Tests/TryDeflateTests.fs
+++ b/tests/FsCodec.Tests/TryDeflateTests.fs
@@ -5,7 +5,7 @@ open Swensen.Unquote
 open Xunit
 
 let inline roundtrip (sut : FsCodec.IEventCodec<_, _, _>) value =
-    let encoded = sut.Encode(context = null, value = value)
+    let encoded = sut.Encode((), value = value)
     let loaded = FsCodec.Core.TimelineEvent.Create(-1L, encoded.EventType, encoded.Data)
     sut.TryDecode loaded
 
@@ -39,14 +39,14 @@ module TryDeflate =
         res' =! ValueSome compressibleValue
 
     let [<Fact>] ``compresses when possible`` () =
-        let encoded = sut.Encode(context = ValueNone, value = compressibleValue)
+        let encoded = sut.Encode((), value = compressibleValue)
         let struct (encoding, encodedValue) = encoded.Data
         encodedValue.Length <! compressibleValue.Length
 
     let [<Fact>] ``uses raw value where compression not possible`` () =
         let value = "NotCompressible"
-        let directResult = StringUtf8.sut.Encode(ValueNone, value).Data
-        let encoded = sut.Encode(context = ValueNone, value = value)
+        let directResult = StringUtf8.sut.Encode((), value).Data
+        let encoded = sut.Encode((), value = value)
         let struct (_encoding, result) = encoded.Data
         true =! directResult.Span.SequenceEqual(result.Span)
 
@@ -62,7 +62,7 @@ module Uncompressed =
         res' =! ValueSome value
 
     let [<Fact>] ``does not compress, even if it was possible to`` () =
-        let directResult = StringUtf8.sut.Encode(ValueNone, value).Data
-        let encoded = sut.Encode(context = ValueNone, value = value)
+        let directResult = StringUtf8.sut.Encode((), value).Data
+        let encoded = sut.Encode((), value)
         let struct (_encoding, result) = encoded.Data
         true =! directResult.Span.SequenceEqual(result.Span)


### PR DESCRIPTION
- Convert all Tuple/Option types to the `struct` versions - can be a touch ugly in usage, but hopefully future F# versions make it less so; also applied to active patterns
- Major other change is to switch `'context` from an `option` that's stubbed as an `obj` to be a `unit` when not relevant
- Add `TimelineEvent.Size` field to allow gathering stats without inspecting the `Data`

Including some minor other profiling-driven optimizations in StreamName