### PR TITLE
Add StreamName.[Cc]ategory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `StreamName.Category` + `category`: Extracts the category portion of a streamName [#85](https://github.com/jet/FsCodec/pull/85)
+
 ### Changed
 ### Removed
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -494,6 +494,10 @@ module StreamName =
     (* Splitting: functions/Active patterns for (i.e. generated via `parse`, `create` or `compose`) well-formed Stream Names
        Will throw if presented with malformed strings [generated via alternate means] *)
 
+    /// Extracts the category portion of the StreamName
+    let category (x : StreamName) : string = ...
+    let (|Category|) = category
+    
     // Splits a well-formed Stream Name of the form {category}-{streamId} into its two elements.
     // Throws <code>InvalidArgumentException</code> if it does not adhere to the well known format (i.e. if it was not produced by `parse`).
     // <remarks>Inverse of <code>create</code>

--- a/src/FsCodec/StreamName.fs
+++ b/src/FsCodec/StreamName.fs
@@ -87,6 +87,13 @@ module StreamName =
     (* Splitting: functions/Active patterns for (i.e. generated via `parse`, `create` or `compose`) well-formed Stream Names
        Will throw if presented with malformed strings [generated via alternate means] *)
 
+    /// Extracts the category portion of the StreamName
+    let category (x : StreamName) =
+        let raw = toString x
+        raw.Substring(0, raw.IndexOf '-')
+    /// Extracts the category portion of a StreamName
+    let (|Category|) = category
+
     /// <summary>Splits a well-formed Stream Name of the form <c>{category}-{streamId}</c> into its two elements.<br/>
     /// Throws <c>InvalidArgumentException</c> if it does not adhere to the well known format (i.e. if it was not produced by `parse`).</summary>
     /// <remarks>Inverse of <c>create</c></remarks>

--- a/tests/FsCodec.NewtonsoftJson.Tests/Examples.fsx
+++ b/tests/FsCodec.NewtonsoftJson.Tests/Examples.fsx
@@ -145,9 +145,9 @@ module Events =
 
     /// Pattern to determine whether a given {category}-{streamId} StreamName represents the stream associated with this Aggregate
     /// Yields a strongly typed id from the streamId if the Category does match
-    let (|StreamName|_|) = function
-        | FsCodec.StreamName.CategoryAndId (Category, ClientId.Parse clientId) -> Some clientId
-        | _ -> None
+    let [<return: Struct>] (|StreamName|_|) = function
+        | FsCodec.StreamName.CategoryAndId (Category, ClientId.Parse clientId) -> ValueSome clientId
+        | _ -> ValueNone
 
     type Added = { item : string }
     type Removed = { name : string }

--- a/tests/FsCodec.SystemTextJson.Tests/Examples.fsx
+++ b/tests/FsCodec.SystemTextJson.Tests/Examples.fsx
@@ -147,9 +147,9 @@ module Events =
 
     /// Pattern to determine whether a given {category}-{streamId} StreamName represents the stream associated with this Aggregate
     /// Yields a strongly typed id from the streamId if the Category does match
-    let (|StreamName|_|) = function
-        | FsCodec.StreamName.CategoryAndId (Category, ClientId.Parse clientId) -> Some clientId
-        | _ -> None
+    let [<return: Struct>] (|StreamName|_|) = function
+        | FsCodec.StreamName.CategoryAndId (Category, ClientId.Parse clientId) -> ValueSome clientId
+        | _ -> ValueNone
 
     type Added = { item : string }
     type Removed = { name : string }


### PR DESCRIPTION
Provides for cleaner pattern matching when filtering by category without having to drop the streamId portion