### PR TITLE
Newtonsoft: Sync TypeSafeEnum signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 ### Changed
 
-- `NewtonsoftJson.TypeSafeEnum`: Sync with `SystemTextJson.TypeSafeEnum` [#88](https://github.com/jet/FsCodec/pull/88) 
+- `NewtonsoftJson.TypeSafeEnum`: Sync with `SystemTextJson.TypeSafeEnum` [#91](https://github.com/jet/FsCodec/pull/91) 
 
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- `NewtonsoftJson.TypeSafeEnum`: Sync with `SystemTextJson.TypeSafeEnum` [#88](https://github.com/jet/FsCodec/pull/88) 
+
 ### Removed
 ### Fixed
 

--- a/src/FsCodec.NewtonsoftJson/OptionConverter.fs
+++ b/src/FsCodec.NewtonsoftJson/OptionConverter.fs
@@ -15,7 +15,7 @@ type OptionConverter() =
             if value = null then null
             else
                 let _, fields = FSharpValue.GetUnionFields(value, value.GetType())
-                fields.[0]
+                fields[0]
 
         serializer.Serialize(writer, value)
 
@@ -26,8 +26,8 @@ type OptionConverter() =
             else innerType
 
         let cases = Union.getUnionCases t
-        if reader.TokenType = JsonToken.Null then FSharpValue.MakeUnion(cases.[0], Array.empty)
+        if reader.TokenType = JsonToken.Null then FSharpValue.MakeUnion(cases[0], Array.empty)
         else
             let value = serializer.Deserialize(reader, innerType)
-            if value = null then FSharpValue.MakeUnion(cases.[0], Array.empty)
-            else FSharpValue.MakeUnion(cases.[1], [|value|])
+            if value = null then FSharpValue.MakeUnion(cases[0], Array.empty)
+            else FSharpValue.MakeUnion(cases[1], [|value|])

--- a/src/FsCodec.NewtonsoftJson/Options.fs
+++ b/src/FsCodec.NewtonsoftJson/Options.fs
@@ -17,13 +17,13 @@ type Options private () =
     /// Creates a default set of serializer settings used by Json serialization. When used with no args, same as JsonSerializerSettings.CreateDefault()
     static member CreateDefault
         (   [<Optional; ParamArray>] converters : JsonConverter[],
-            /// Use multi-line, indented formatting when serializing JSON; defaults to false.
+            // Use multi-line, indented formatting when serializing JSON; defaults to false.
             [<Optional; DefaultParameterValue(null)>] ?indent : bool,
-            /// Render idiomatic camelCase for PascalCase items by using `CamelCasePropertyNamesContractResolver`. Defaults to false.
+            // Render idiomatic camelCase for PascalCase items by using `CamelCasePropertyNamesContractResolver`. Defaults to false.
             [<Optional; DefaultParameterValue(null)>] ?camelCase : bool,
-            /// Ignore null values in input data; defaults to false.
+            // Ignore null values in input data; defaults to false.
             [<Optional; DefaultParameterValue(null)>] ?ignoreNulls : bool,
-            /// Error on missing values (as opposed to letting them just be default-initialized); defaults to false.
+            // Error on missing values (as opposed to letting them just be default-initialized); defaults to false.
             [<Optional; DefaultParameterValue(null)>] ?errorOnMissing : bool) =
 
         let indent = defaultArg indent false
@@ -48,16 +48,16 @@ type Options private () =
     /// - Always prepends an OptionConverter() to any converters supplied
     /// - everything else is as per CreateDefault:- i.e. emit nulls instead of omitting fields etc
     static member Create
-        (   /// List of converters to apply. An implicit OptionConverter() will be prepended and/or be used as a default
+        (   // List of converters to apply. An implicit OptionConverter() will be prepended and/or be used as a default
             [<Optional; ParamArray>] converters : JsonConverter[],
-            /// Use multi-line, indented formatting when serializing JSON; defaults to false.
+            // Use multi-line, indented formatting when serializing JSON; defaults to false.
             [<Optional; DefaultParameterValue(null)>] ?indent : bool,
-            /// Render idiomatic camelCase for PascalCase items by using `CamelCasePropertyNamesContractResolver`.
-            ///  Defaults to false on basis that you'll use record and tuple field names that are camelCase (and hence not `CLSCompliant`).
+            // Render idiomatic camelCase for PascalCase items by using `CamelCasePropertyNamesContractResolver`.
+            //  Defaults to false on basis that you'll use record and tuple field names that are camelCase (and hence not `CLSCompliant`).
             [<Optional; DefaultParameterValue(null)>] ?camelCase : bool,
-            /// Ignore null values in input data; defaults to `false`.
+            // Ignore null values in input data; defaults to `false`.
             [<Optional; DefaultParameterValue(null)>] ?ignoreNulls : bool,
-            /// Error on missing values (as opposed to letting them just be default-initialized); defaults to false
+            // Error on missing values (as opposed to letting them just be default-initialized); defaults to false
             [<Optional; DefaultParameterValue(null)>] ?errorOnMissing : bool) =
 
         Options.CreateDefault(

--- a/src/FsCodec.NewtonsoftJson/TypeSafeEnumConverter.fs
+++ b/src/FsCodec.NewtonsoftJson/TypeSafeEnumConverter.fs
@@ -26,10 +26,12 @@ module TypeSafeEnum =
             raise (KeyNotFoundException(sprintf "Could not find case '%s' for type '%s'" str t.FullName))
     let parse<'T> (str : string) = parseT typeof<'T> str :?> 'T
 
-    let toString<'t> (x : 't) =
-        let u = Union.getInfo typeof<'t>
+    let toStringT (t : Type) (x : obj) =
+        let u = Union.getInfo t
         let tag = u.tagReader x
         u.cases[tag].Name
+    let toString<'t> (x : 't) =
+        toStringT typeof<'t> x
 
 /// Maps strings to/from Union cases; refuses to convert for values not in the Union
 type TypeSafeEnumConverter() =
@@ -39,7 +41,7 @@ type TypeSafeEnumConverter() =
         TypeSafeEnum.isTypeSafeEnum t
 
     override _.WriteJson(writer : JsonWriter, value : obj, _ : JsonSerializer) =
-        let str = TypeSafeEnum.toString value
+        let str = TypeSafeEnum.toStringT (value.GetType()) value
         writer.WriteValue str
 
     override _.ReadJson(reader : JsonReader, t : Type, _ : obj, _ : JsonSerializer) =

--- a/src/FsCodec.NewtonsoftJson/UnionConverter.fs
+++ b/src/FsCodec.NewtonsoftJson/UnionConverter.fs
@@ -30,7 +30,7 @@ module private Union =
         }
     let getInfo = memoize createInfo
 
-    /// Allows us to distinguish between Unions that have bodies and hence should use a UnionConverter
+    /// Allows us to distinguish Unions that do not have bodies and hence should use a TypeSafeEnumConverter
     let hasOnlyNullaryCases (t : Type) =
         let union = getInfo t
         union.cases |> Seq.forall (fun case -> case.GetFields().Length = 0)

--- a/src/FsCodec.NewtonsoftJson/UnionConverter.fs
+++ b/src/FsCodec.NewtonsoftJson/UnionConverter.fs
@@ -20,7 +20,7 @@ module private Union =
     let isUnion = memoize (fun t -> FSharpType.IsUnion(t, true))
     let getUnionCases = memoize (fun t -> FSharpType.GetUnionCases(t, true))
 
-    let private createUnion t =
+    let private createInfo t =
         let cases = getUnionCases t
         {
             cases = cases
@@ -28,7 +28,12 @@ module private Union =
             fieldReader = cases |> Array.map (fun c -> FSharpValue.PreComputeUnionReader(c, true))
             caseConstructor = cases |> Array.map (fun c -> FSharpValue.PreComputeUnionConstructor(c, true))
         }
-    let getUnion = memoize createUnion
+    let getInfo = memoize createInfo
+
+    /// Allows us to distinguish between Unions that have bodies and hence should use a UnionConverter
+    let hasOnlyNullaryCases (t : Type) =
+        let union = getInfo t
+        union.cases |> Seq.forall (fun case -> case.GetFields().Length = 0)
 
     /// Parallels F# behavior wrt how it generates a DU's underlying .NET Type
     let inline isInlinedIntoUnionItem (t : Type) =
@@ -53,7 +58,7 @@ module private Union =
             [| inputJObject.ToObject(singleCaseArg.PropertyType, serializer) |]
         | multipleFieldsInCustomCaseType ->
             [| for fi in multipleFieldsInCustomCaseType ->
-                match inputJObject.[fi.Name] with
+                match inputJObject[fi.Name] with
                 | null when
                     // Afford converters an opportunity to handle the missing field in the best way I can figure out to signal that
                     // The specific need being covered (see tests) is to ensure that, even with MissingMemberHandling=Ignore,
@@ -79,10 +84,10 @@ type UnionConverter private (discriminator : string, ?catchAllCase) =
     override _.CanConvert (t : Type) = Union.isUnion t
 
     override _.WriteJson(writer : JsonWriter, value : obj, serializer : JsonSerializer) =
-        let union = Union.getUnion (value.GetType())
+        let union = Union.getInfo (value.GetType())
         let tag = union.tagReader value
-        let case = union.cases.[tag]
-        let fieldValues = union.fieldReader.[tag] value
+        let case = union.cases[tag]
+        let fieldValues = union.fieldReader[tag] value
         let fieldInfos = case.GetFields()
 
         writer.WriteStartObject()
@@ -92,7 +97,7 @@ type UnionConverter private (discriminator : string, ?catchAllCase) =
 
         match fieldInfos with
         | [| fi |] when not (Union.typeIsUnionWithConverterAttribute fi.PropertyType) ->
-            match fieldValues.[0] with
+            match fieldValues[0] with
             | null when serializer.NullValueHandling = NullValueHandling.Ignore -> ()
             | fv ->
                 let token = if fv = null then JToken.Parse "null" else JToken.FromObject(fv, serializer)
@@ -117,9 +122,9 @@ type UnionConverter private (discriminator : string, ?catchAllCase) =
         if token.Type <> JTokenType.Object then raise (FormatException(sprintf "Expected object token, got %O" token.Type))
         let inputJObject = token :?> JObject
 
-        let union = Union.getUnion t
+        let union = Union.getInfo t
         let targetCaseIndex =
-            let inputCaseNameValue = inputJObject.[discriminator] |> string
+            let inputCaseNameValue = inputJObject[discriminator] |> string
             let findCaseNamed x = union.cases |> Array.tryFindIndex (fun case -> case.Name = x)
             match findCaseNamed inputCaseNameValue, catchAllCase  with
             | None, None ->
@@ -133,5 +138,5 @@ type UnionConverter private (discriminator : string, ?catchAllCase) =
                         inputCaseNameValue catchAllCaseName t.FullName |> invalidOp
                 | Some foundIndex -> foundIndex
 
-        let targetCaseFields, targetCaseCtor = union.cases.[targetCaseIndex].GetFields(), union.caseConstructor.[targetCaseIndex]
+        let targetCaseFields, targetCaseCtor = union.cases[targetCaseIndex].GetFields(), union.caseConstructor[targetCaseIndex]
         targetCaseCtor (Union.mapTargetCaseArgs inputJObject serializer targetCaseFields)

--- a/src/FsCodec.SystemTextJson/Options.fs
+++ b/src/FsCodec.SystemTextJson/Options.fs
@@ -17,13 +17,13 @@ type Options private () =
     /// Creates a default set of serializer options used by Json serialization. When used with no args, same as `JsonSerializerOptions()`
     static member CreateDefault
         (   [<Optional; ParamArray>] converters : JsonConverter[],
-            /// Use multi-line, indented formatting when serializing JSON; defaults to false.
+            // Use multi-line, indented formatting when serializing JSON; defaults to false.
             [<Optional; DefaultParameterValue(null)>] ?indent : bool,
-            /// Render idiomatic camelCase for PascalCase items by using `PropertyNamingPolicy = CamelCase`. Defaults to false.
+            // Render idiomatic camelCase for PascalCase items by using `PropertyNamingPolicy = CamelCase`. Defaults to false.
             [<Optional; DefaultParameterValue(null)>] ?camelCase : bool,
-            /// Ignore null values in input data, don't render fields with null values; defaults to `false`.
+            // Ignore null values in input data, don't render fields with null values; defaults to `false`.
             [<Optional; DefaultParameterValue(null)>] ?ignoreNulls : bool,
-            /// Drop escaping of HTML-sensitive characters. defaults to `false`.
+            // Drop escaping of HTML-sensitive characters. defaults to `false`.
             [<Optional; DefaultParameterValue(null)>] ?unsafeRelaxedJsonEscaping : bool) =
 
         let indent = defaultArg indent false
@@ -43,22 +43,22 @@ type Options private () =
     /// - renders values with `UnsafeRelaxedJsonEscaping` - i.e. minimal escaping as per `NewtonsoftJson`<br/>
     /// Everything else is as per CreateDefault:- i.e. emit nulls instead of omitting fields, no indenting, no camelCase conversion
     static member Create
-        (   /// List of converters to apply. Implicit converters may be prepended and/or be used as a default
+        (   // List of converters to apply. Implicit converters may be prepended and/or be used as a default
             [<Optional; ParamArray>] converters : JsonConverter[],
-            /// Use multi-line, indented formatting when serializing JSON; defaults to false.
+            // Use multi-line, indented formatting when serializing JSON; defaults to false.
             [<Optional; DefaultParameterValue(null)>] ?indent : bool,
-            /// Render idiomatic camelCase for PascalCase items by using `PropertyNamingPolicy = CamelCase`.
-            ///  Defaults to false on basis that you'll use record and tuple field names that are camelCase (but thus not `CLSCompliant`).
+            // Render idiomatic camelCase for PascalCase items by using `PropertyNamingPolicy = CamelCase`.
+            //  Defaults to false on basis that you'll use record and tuple field names that are camelCase (but thus not `CLSCompliant`).
             [<Optional; DefaultParameterValue(null)>] ?camelCase : bool,
-            /// Ignore null values in input data, don't render fields with null values; defaults to `false`.
+            // Ignore null values in input data, don't render fields with null values; defaults to `false`.
             [<Optional; DefaultParameterValue(null)>] ?ignoreNulls : bool,
-            /// Drop escaping of HTML-sensitive characters. defaults to `true`.
+            // Drop escaping of HTML-sensitive characters. defaults to `true`.
             [<Optional; DefaultParameterValue(null)>] ?unsafeRelaxedJsonEscaping : bool,
-            /// <summary>Apply <c>TypeSafeEnumConverter</c> if possible. Defaults to <c>false</c>.</summary>
+            // <summary>Apply <c>TypeSafeEnumConverter</c> if possible. Defaults to <c>false</c>.</summary>
             [<Optional; DefaultParameterValue(null)>] ?autoTypeSafeEnumToJsonString : bool,
-            /// <summary>Apply <c>UnionConverter</c> for all Discriminated Unions, if <c>TypeSafeEnumConverter</c> not possible. Defaults to <c>false</c>.</summary>
+            // <summary>Apply <c>UnionConverter</c> for all Discriminated Unions, if <c>TypeSafeEnumConverter</c> not possible. Defaults to <c>false</c>.</summary>
             [<Optional; DefaultParameterValue(null)>] ?autoUnionToJsonObject : bool,
-            /// <summary>Apply <c>RejectNullStringConverter</c> in order to have serialization throw on <c>null</c> strings. Use <c>string option</c> to represent strings that can potentially be <c>null</c>.
+            // <summary>Apply <c>RejectNullStringConverter</c> in order to have serialization throw on <c>null</c> strings. Use <c>string option</c> to represent strings that can potentially be <c>null</c>.
             [<Optional; DefaultParameterValue(null)>] ?rejectNullStrings: bool) =
 
         let autoTypeSafeEnumToJsonString = defaultArg autoTypeSafeEnumToJsonString false

--- a/src/FsCodec.SystemTextJson/UnionConverter.fs
+++ b/src/FsCodec.SystemTextJson/UnionConverter.fs
@@ -50,7 +50,7 @@ module private Union =
                 |> Option.map (fun a -> a :?> IUnionConverterOptions) }
     let getInfo : Type -> Union = memoize createInfo
 
-    /// Allows us to distinguish between Unions that have bodies and hence should use a UnionConverter
+    /// Allows us to distinguish Unions that do not have bodies and hence should use a TypeSafeEnumConverter
     let hasOnlyNullaryCases (t : Type) =
         let union = getInfo t
         union.cases |> Seq.forall (fun case -> case.GetFields().Length = 0)

--- a/src/FsCodec.SystemTextJson/UnionConverter.fs
+++ b/src/FsCodec.SystemTextJson/UnionConverter.fs
@@ -50,7 +50,7 @@ module private Union =
                 |> Option.map (fun a -> a :?> IUnionConverterOptions) }
     let getInfo : Type -> Union = memoize createInfo
 
-    /// Allows us to distinguish between Unions that have bodies and hence should UnionConverter
+    /// Allows us to distinguish between Unions that have bodies and hence should use a UnionConverter
     let hasOnlyNullaryCases (t : Type) =
         let union = getInfo t
         union.cases |> Seq.forall (fun case -> case.GetFields().Length = 0)
@@ -69,8 +69,8 @@ type UnionConverter<'T>() =
         let union = Union.getInfo typeof<'T>
         let unionOptions = getOptions union
         let tag = union.tagReader value
-        let case = union.cases.[tag]
-        let fieldValues = union.fieldReader.[tag] value
+        let case = union.cases[tag]
+        let fieldValues = union.fieldReader[tag] value
         let fieldInfos = case.GetFields()
 
         writer.WriteStartObject()
@@ -111,7 +111,7 @@ type UnionConverter<'T>() =
                         inputCaseNameValue catchAllCaseName t.FullName |> invalidOp
                 | Some foundIndex -> foundIndex
 
-        let targetCaseFields, targetCaseCtor = union.cases.[targetCaseIndex].GetFields(), union.caseConstructor.[targetCaseIndex]
+        let targetCaseFields, targetCaseCtor = union.cases[targetCaseIndex].GetFields(), union.caseConstructor[targetCaseIndex]
         let ctorArgs =
             [| for fieldInfo in targetCaseFields ->
                 let t = fieldInfo.PropertyType


### PR DESCRIPTION
While we still have separate impls per serializer, this aligns the signatures