### PR TITLE
feat(TypeSafeEnum): Merged impls; exposed Union

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,17 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `Union`: Exposed internal type, featuring `isUnion`, `isNullary`, and `caseName` (that's not tied to `TypeSafeEnum`), [#102](https://github.com/jet/FsCodec/pull/102)
+
 ### Changed
+
+- `TypeSafeEnum`: Merged two impls from `SystemTextJson` and `NewtonsoftJson` [#102](https://github.com/jet/FsCodec/pull/102)
+
 ### Removed
+
+- `(NewtonsoftJson|SystemTextJson).TypeSafeEnum`: Merged/moved to `FsCodec.TypeSafeEnum` [#102](https://github.com/jet/FsCodec/pull/102)
+
 ### Fixed
 
 <a name="3.0.0-rc.11"></a>

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ _The single most complete set of `System.Text.Json` Converters is the [`FSharp.S
 ### Core converters
 
 The respective concrete Codec packages include relevant `Converter`/`JsonConverter` in order to facilitate interoperable and versionable renderings:
-  - [`TypeSafeEnumConverter`](https://github.com/jet/FsCodec/blob/master/src/FsCodec.NewtonsoftJson/TypeSafeEnumConverter.fs#L33) represents discriminated union (whose cases are all nullary), as a `string` in a trustworthy manner (`Newtonsoft.Json.Converters.StringEnumConverter` permits values outside the declared values) :pray: [@amjjd](https://github.com/amjjd)
-  - [`UnionConverter`](https://github.com/jet/FsCodec/blob/master/src/FsCodec.NewtonsoftJson/UnionConverter.fs#L71) represents F# discriminated unions as a single JSON `object` with both the tag value and the body content as named fields directly within :pray: [@amjdd](https://github.com/amjjd); `System.Text.Json` reimplementation :pray: [@NickDarvey](https://github.com/NickDarvey)
+  - [`TypeSafeEnumConverter`](https://github.com/jet/FsCodec/blob/master/src/FsCodec.SystemTextJson/TypeSafeEnumConverter.fs) represents discriminated union (whose cases are all nullary), as a `string` in a trustworthy manner (`Newtonsoft.Json.Converters.StringEnumConverter` permits values outside the declared values) :pray: [@amjjd](https://github.com/amjjd)
+  - [`UnionConverter`](https://github.com/jet/FsCodec/blob/master/src/FsCodec.SystemTextJson/UnionConverter.fs#L23) represents F# discriminated unions as a single JSON `object` with both the tag value and the body content as named fields directly within :pray: [@amjdd](https://github.com/amjjd); `System.Text.Json` reimplementation :pray: [@NickDarvey](https://github.com/NickDarvey)
   
     NOTE: The encoding differs from that provided by `Newtonsoft.Json`'s default converter: `Newtonsoft.Json.Converters.DiscriminatedUnionConverter`, which encodes the fields as an array without names, which has some pros, but many obvious cons
     
@@ -305,10 +305,10 @@ type OutcomeWithOther = Joy | Pain | Misery | Other
 and OutcomeWithCatchAllConverter() =
     inherit JsonIsomorphism<OutcomeWithOther, string>()
     override _.Pickle v =
-        TypeSafeEnum.toString v
+        FsCodec.TypeSafeEnum.toString v
     override _.UnPickle json =
         json
-        |> TypeSafeEnum.tryParse<OutcomeWithOther>
+        |> FsCodec.TypeSafeEnum.tryParse<OutcomeWithOther>
         |> Option.defaultValue Other
 
 type Message2 = { name: string option; outcome: OutcomeWithOther }

--- a/src/FsCodec.NewtonsoftJson/OptionConverter.fs
+++ b/src/FsCodec.NewtonsoftJson/OptionConverter.fs
@@ -8,9 +8,9 @@ open System
 type OptionConverter() =
     inherit JsonConverter()
 
-    override _.CanConvert(t : Type) = t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<option<_>>
+    override _.CanConvert(t: Type) = t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<option<_>>
 
-    override _.WriteJson(writer : JsonWriter, value : obj, serializer : JsonSerializer) =
+    override _.WriteJson(writer: JsonWriter, value: obj, serializer: JsonSerializer) =
         let value =
             if value = null then null
             else
@@ -19,15 +19,15 @@ type OptionConverter() =
 
         serializer.Serialize(writer, value)
 
-    override _.ReadJson(reader : JsonReader, t : Type, _existingValue : obj, serializer : JsonSerializer) =
+    override _.ReadJson(reader: JsonReader, t: Type, _existingValue: obj, serializer: JsonSerializer) =
         let innerType =
             let innerType = t.GetGenericArguments().[0]
             if innerType.IsValueType then typedefof<Nullable<_>>.MakeGenericType(innerType)
             else innerType
 
-        let cases = Union.getUnionCases t
+        let cases = let ui = FsCodec.Union.Info.get t in ui.cases
         if reader.TokenType = JsonToken.Null then FSharpValue.MakeUnion(cases[0], Array.empty)
         else
             let value = serializer.Deserialize(reader, innerType)
             if value = null then FSharpValue.MakeUnion(cases[0], Array.empty)
-            else FSharpValue.MakeUnion(cases[1], [|value|])
+            else FSharpValue.MakeUnion(cases[1], [| value |])

--- a/src/FsCodec.NewtonsoftJson/Pickler.fs
+++ b/src/FsCodec.NewtonsoftJson/Pickler.fs
@@ -5,11 +5,9 @@ open System
 
 [<AutoOpen>]
 module private Prelude =
-    /// Provides a thread-safe memoization wrapper for supplied function
-    let memoize : ('T -> 'S) -> 'T -> 'S =
-        fun f ->
-            let cache = new System.Collections.Concurrent.ConcurrentDictionary<'T, 'S>()
-            fun t -> cache.GetOrAdd(t, f)
+    let memoize (f: 'T -> 'S): 'T -> 'S =
+        let cache = new System.Collections.Concurrent.ConcurrentDictionary<'T, 'S>()
+        fun t -> cache.GetOrAdd(t, f)
 
 [<AbstractClass>]
 type JsonPickler<'T>() =

--- a/src/FsCodec.NewtonsoftJson/TypeSafeEnumConverter.fs
+++ b/src/FsCodec.NewtonsoftJson/TypeSafeEnumConverter.fs
@@ -2,50 +2,21 @@
 
 open Newtonsoft.Json
 open System
-open System.Collections.Generic
-
-/// Utilities for working with DUs where none of the cases have a value
-module TypeSafeEnum =
-
-    let isTypeSafeEnum (t : Type) =
-        Union.isUnion t
-        && Union.hasOnlyNullaryCases t
-
-    let tryParseT (t : Type) (str : string) =
-        let u = Union.getInfo t
-        u.cases
-        |> Array.tryFindIndex (fun c -> c.Name = str)
-        |> Option.map (fun tag -> u.caseConstructor[tag] [||])
-    let tryParse<'T> (str : string) = tryParseT typeof<'T> str |> Option.map (fun e -> e :?> 'T)
-
-    let parseT (t : Type) (str : string) =
-        match tryParseT t str with
-        | Some e -> e
-        | None   ->
-            // Keep exception compat, but augment with a meaningful message.
-            raise (KeyNotFoundException(sprintf "Could not find case '%s' for type '%s'" str t.FullName))
-    let parse<'T> (str : string) = parseT typeof<'T> str :?> 'T
-
-    let toStringT (t : Type) (x : obj) =
-        let u = Union.getInfo t
-        let tag = u.tagReader x
-        u.cases[tag].Name
-    let toString<'t> (x : 't) =
-        toStringT typeof<'t> x
 
 /// Maps strings to/from Union cases; refuses to convert for values not in the Union
 type TypeSafeEnumConverter() =
     inherit JsonConverter()
 
-    override _.CanConvert(t : Type) =
-        TypeSafeEnum.isTypeSafeEnum t
+    override _.CanConvert(t: Type) =
+        FsCodec.TypeSafeEnum.isTypeSafeEnum t
 
-    override _.WriteJson(writer : JsonWriter, value : obj, _ : JsonSerializer) =
-        let str = TypeSafeEnum.toStringT (value.GetType()) value
+    override _.WriteJson(writer: JsonWriter, value: obj, _: JsonSerializer) =
+        let t = value.GetType()
+        let str = FsCodec.Union.caseNameT t value
         writer.WriteValue str
 
-    override _.ReadJson(reader : JsonReader, t : Type, _ : obj, _ : JsonSerializer) =
+    override _.ReadJson(reader : JsonReader, t: Type, _: obj, _: JsonSerializer) =
         if reader.TokenType <> JsonToken.String then
             sprintf "Unexpected token when reading TypeSafeEnum: %O" reader.TokenType |> JsonSerializationException |> raise
         let str = reader.Value :?> string
-        TypeSafeEnum.parseT t str
+        FsCodec.TypeSafeEnum.parseT t str

--- a/src/FsCodec.NewtonsoftJson/UnionConverter.fs
+++ b/src/FsCodec.NewtonsoftJson/UnionConverter.fs
@@ -1,6 +1,5 @@
 ﻿namespace FsCodec.NewtonsoftJson
 
-open FSharp.Reflection
 open Newtonsoft.Json
 open Newtonsoft.Json.Linq
 open System
@@ -8,9 +7,6 @@ open System.Reflection
 
 [<NoComparison; NoEquality>]
 module private UnionInfo =
-
-    let getFieldReaders: Type -> (obj -> obj[])[] = memoize (fun t ->
-        (FsCodec.Union.Info.get t).cases |> Array.map (fun c -> FSharpValue.PreComputeUnionReader(c, true)))
 
     /// Parallels F# behavior wrt how it generates a DU's underlying .NET Type
     let inline isInlinedIntoUnionItem (t: Type) =
@@ -21,12 +17,12 @@ module private UnionInfo =
            && (typedefof<Option<_>> = t.GetGenericTypeDefinition()
                 || t.GetGenericTypeDefinition().IsValueType)) // Nullable<T>
 
-    let typeHasJsonConverterAttribute = memoize (fun (t: Type) -> t.IsDefined(typeof<JsonConverterAttribute>))
-    let typeIsUnionWithConverterAttribute = memoize (fun (t: Type) -> FsCodec.Union.isUnion t && typeHasJsonConverterAttribute t)
+    let typeHasConverterAttribute = memoize (fun (t: Type) -> t.IsDefined(typeof<JsonConverterAttribute>))
+    let typeIsUnionWithConverterAttribute = memoize (fun (t: Type) -> FsCodec.Union.isUnion t && typeHasConverterAttribute t)
 
     let propTypeRequiresConstruction (propertyType: Type) =
         not (isInlinedIntoUnionItem propertyType)
-        && not (typeHasJsonConverterAttribute propertyType)
+        && not (typeHasConverterAttribute propertyType)
 
     /// Prepare arguments for the Case class ctor based on the kind of case and how F# maps that to a Type
     /// and/or whether we need to let json.net step in to convert argument types
@@ -41,7 +37,7 @@ module private UnionInfo =
                     // The specific need being covered (see tests) is to ensure that, even with MissingMemberHandling=Ignore,
                     // the TypeSafeEnumConverter should reject missing values
                     // not having this case would go direct to `null` without passing go
-                    typeHasJsonConverterAttribute fi.PropertyType
+                    typeHasConverterAttribute fi.PropertyType
                     || serializer.MissingMemberHandling = MissingMemberHandling.Error ->
                         // NB caller can opt out of erroring by setting NullValueHandling = NullValueHandling.Ignore)
                         // which renders the following equivalent to the next case
@@ -61,20 +57,14 @@ type UnionConverter private (discriminator: string, ?catchAllCase) =
     override _.CanConvert(t: Type) = FsCodec.Union.isUnion t
 
     override _.WriteJson(writer: JsonWriter, value: obj, serializer: JsonSerializer) =
-        let t = value.GetType()
-        let ui = FsCodec.Union.Info.get t
-        let tag = ui.tagReader value
-        let case = ui.cases[tag]
-        let fieldReaders = UnionInfo.getFieldReaders t
-        let fieldValues = fieldReaders[tag] value
-        let fieldInfos = case.GetFields()
-
         writer.WriteStartObject()
 
         writer.WritePropertyName(discriminator)
-        writer.WriteValue(case.Name)
+        let case = (FsCodec.Union.Info.get (value.GetType())).getCase value
+        writer.WriteValue(case.name)
 
-        match fieldInfos with
+        let fieldValues = case.deconstruct value
+        match case.fields with
         | [| fi |] when not (UnionInfo.typeIsUnionWithConverterAttribute fi.PropertyType) ->
             match fieldValues[0] with
             | null when serializer.NullValueHandling = NullValueHandling.Ignore -> ()
@@ -89,7 +79,7 @@ type UnionConverter private (discriminator: string, ?catchAllCase) =
                     writer.WritePropertyName(fi.Name)
                     token.WriteTo writer
         | _ ->
-            for fieldInfo, fieldValue in Seq.zip fieldInfos fieldValues do
+            for fieldInfo, fieldValue in Seq.zip case.fields fieldValues do
                 if fieldValue <> null || serializer.NullValueHandling = NullValueHandling.Include then
                     writer.WritePropertyName(fieldInfo.Name)
                     serializer.Serialize(writer, fieldValue)
@@ -101,21 +91,18 @@ type UnionConverter private (discriminator: string, ?catchAllCase) =
         if token.Type <> JTokenType.Object then raise (FormatException(sprintf "Expected object token, got %O" token.Type))
         let inputJObject = token :?> JObject
 
-        let ui = FsCodec.Union.Info.get t
-        let targetCaseTag =
+        let targetCase =
+            let findCaseNamed x = FsCodec.Union.Info.tryFindCaseWithName (FsCodec.Union.Info.get t) ((=) x)
             let inputCaseNameValue = inputJObject[discriminator] |> string
-            let findCaseNamed x = ui.cases |> Array.tryFindIndex (fun case -> case.Name = x)
-            match findCaseNamed inputCaseNameValue, catchAllCase  with
+            match findCaseNamed inputCaseNameValue, catchAllCase with
             | None, None ->
                 sprintf "No case defined for '%s', and no catchAllCase nominated for '%s' on type '%s'"
                     inputCaseNameValue typeof<UnionConverter>.Name t.FullName |> invalidOp
-            | Some foundIndex, _ -> foundIndex
+            | Some c, _ -> c
             | None, Some catchAllCaseName ->
                 match findCaseNamed catchAllCaseName with
                 | None ->
                     sprintf "No case defined for '%s', nominated catchAllCase: '%s' not found in type '%s'"
                         inputCaseNameValue catchAllCaseName t.FullName |> invalidOp
-                | Some foundIndex -> foundIndex
-
-        let targetCaseFields, targetCaseCtor = ui.cases[targetCaseTag].GetFields(), ui.caseConstructor[targetCaseTag]
-        targetCaseCtor (UnionInfo.mapTargetCaseArgs inputJObject serializer targetCaseFields)
+                | Some c -> c
+        targetCase.construct(UnionInfo.mapTargetCaseArgs inputJObject serializer targetCase.fields)

--- a/src/FsCodec.SystemTextJson/Pickler.fs
+++ b/src/FsCodec.SystemTextJson/Pickler.fs
@@ -5,11 +5,9 @@ open System.Text.Json
 
 [<AutoOpen>]
 module private Prelude =
-    /// Provides a thread-safe memoization wrapper for supplied function
-    let memoize : ('T -> 'S) -> 'T -> 'S =
-        fun f ->
-            let cache = System.Collections.Concurrent.ConcurrentDictionary<'T, 'S>()
-            fun t -> cache.GetOrAdd(t, f)
+    let memoize (f: 'T -> 'S): 'T -> 'S =
+        let cache = new System.Collections.Concurrent.ConcurrentDictionary<'T, 'S>()
+        fun t -> cache.GetOrAdd(t, f)
 
 [<AbstractClass>]
 type JsonPickler<'T>() =
@@ -56,5 +54,4 @@ type JsonIsomorphism<'T, 'U>(?targetPickler : JsonPickler<'U>) =
             match targetPickler with
             | None -> JsonSerializer.Deserialize<'U>(&reader,options)
             | Some p -> p.Read(&reader, options)
-
         x.UnPickle target

--- a/src/FsCodec.SystemTextJson/TypeSafeEnumConverter.fs
+++ b/src/FsCodec.SystemTextJson/TypeSafeEnumConverter.fs
@@ -1,62 +1,22 @@
 ﻿namespace FsCodec.SystemTextJson
 
 open System
-open System.Collections.Generic
-open System.ComponentModel
 open System.Text.Json
-
-/// Utilities for working with DUs where none of the cases have a value
-module TypeSafeEnum =
-
-    let isTypeSafeEnum (t: Type) =
-        Union.isUnion t
-        && Union.hasOnlyNullaryCases t
-
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
-    let tryParseTF (t: Type) =
-        let u = Union.getInfo t
-        fun predicate ->
-            u.cases
-            |> Array.tryFindIndex (fun c -> predicate c.Name)
-            |> Option.map (fun tag -> u.caseConstructor[tag] [||])
-    let tryParseF<'T> = let p = tryParseTF typeof<'T> in fun f str -> p (f str) |> Option.map (fun e -> e :?> 'T)
-    let tryParse<'T> = tryParseF<'T> (=)
-
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
-    let parseTF (t: Type) predicate =
-        let p = tryParseTF t
-        fun (str: string) ->
-            match p (predicate str) with
-            | Some e -> e
-            | None ->
-                // Keep exception compat, but augment with a meaningful message.
-                raise (KeyNotFoundException(sprintf "Could not find case '%s' for type '%s'" str t.FullName))
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
-    let parseT (t: Type) = parseTF t (=)
-    let parseF<'T> f =
-        let p = parseTF typeof<'T> f
-        fun (str: string) -> p str :?> 'T
-    let parse<'T> = parseF<'T> (=)
-
-    let toString<'t> =
-        let u = Union.getInfo typeof<'t>
-        fun (x: 't) ->
-            let tag = u.tagReader x
-            u.cases[tag].Name
 
 /// Maps strings to/from Union cases; refuses to convert for values not in the Union
 type TypeSafeEnumConverter<'T>() =
     inherit Serialization.JsonConverter<'T>()
 
-    override _.CanConvert(t : Type) =
-        t = typedefof<'T> && TypeSafeEnum.isTypeSafeEnum typedefof<'T>
+    override _.CanConvert(t: Type) =
+        let tt = typedefof<'T>
+        t = tt && FsCodec.Union.isUnion tt && FsCodec.Union.isNullary tt
 
     override _.Write(writer, value, _options) =
-        let str = TypeSafeEnum.toString value
+        let str = FsCodec.TypeSafeEnum.toString value
         writer.WriteStringValue str
 
     override _.Read(reader, _t, _options) =
         if reader.TokenType <> JsonTokenType.String then
             sprintf "Unexpected token when reading TypeSafeEnum: %O" reader.TokenType |> JsonException |> raise
         let str = reader.GetString()
-        TypeSafeEnum.parse<'T> str
+        FsCodec.TypeSafeEnum.parse<'T> str

--- a/src/FsCodec.SystemTextJson/UnionConverter.fs
+++ b/src/FsCodec.SystemTextJson/UnionConverter.fs
@@ -4,69 +4,41 @@ open FSharp.Reflection
 open System
 open System.Text.Json
 
-[<Interface>]
-type IUnionConverterOptions =
-    abstract member Discriminator: string with get
-    abstract member CatchAllCase: string option with get
-
 /// <summary>Use this attribute in combination with a JsonConverter / UnionConverter attribute to specify
 /// your own name for a discriminator and/or a catch-all case for a specific discriminated union.</summary>
 /// <example><c>[JsonConverter typeof &lt; UnionConverter &lt; T &gt; &gt;); JsonUnionConverterOptions("type") &gt;]</c></example>
 [<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Struct, AllowMultiple = false, Inherited = false)>]
 type JsonUnionConverterOptionsAttribute(discriminator : string) =
     inherit Attribute()
-        member val CatchAllCase: string = null with get, set
-    interface IUnionConverterOptions with
-        member _.Discriminator = discriminator
-        member x.CatchAllCase = Option.ofObj x.CatchAllCase
+    member val internal DiscriminatorPropName = discriminator
+    member val CatchAllCase: string = null with get, set
 
-type private UnionConverterOptions =
-    {   discriminator: string
-        catchAllCase: string option }
-    interface IUnionConverterOptions with
-        member x.Discriminator = x.discriminator
-        member x.CatchAllCase = x.catchAllCase
-
-[<NoComparison; NoEquality>]
-type private UnionInfo =
-    {   fieldReader: (obj -> obj[])[]
-        options: IUnionConverterOptions option }
-module private UnionInfo =
-    let get: Type -> UnionInfo = memoize (fun t ->
-        let i = FsCodec.Union.Info.get t
-        {   fieldReader = i.cases |> Array.map (fun c -> FSharpValue.PreComputeUnionReader(c, true))
-            options =
-                t.GetCustomAttributes(typeof<JsonUnionConverterOptionsAttribute>, false)
-                |> Array.tryHead // could be tryExactlyOne as AttributeUsage(AllowMultiple = false)
-                |> Option.map (fun a -> a :?> IUnionConverterOptions) })
-    let internal hasConverterAttribute = memoize (fun (t: Type) -> t.IsDefined(typeof<Serialization.JsonConverterAttribute>, true))
+module private UnionConverterOptions =
+    let private defaultOptions = JsonUnionConverterOptionsAttribute("case", CatchAllCase = null)
+    let get (t: Type) =
+        match t.GetCustomAttributes(typeof<JsonUnionConverterOptionsAttribute>, false) with
+        | [||] -> defaultOptions
+        | xs -> Array.exactlyOne xs :?> _ // AttributeUsage(AllowMultiple = false)
 
 type UnionConverter<'T>() =
     inherit Serialization.JsonConverter<'T>()
 
-    static let defaultConverterOptions = { discriminator = "case"; catchAllCase = None } :> IUnionConverterOptions
+    let converterOptions = UnionConverterOptions.get typeof<'T>
+    let info = FsCodec.Union.Info.get typeof<'T>
 
-    let getOptions union = defaultArg union.options defaultConverterOptions
+    override _.CanConvert(t: Type) = t = typeof<'T> && FsCodec.Union.isUnion t
 
-    override _.CanConvert(t : Type) = t = typeof<'T> && FsCodec.Union.isUnion t
-
-    override _.Write(writer, value, options) =
+    override _.Write(writer: Utf8JsonWriter, value, options: JsonSerializerOptions) =
         let value = box value
-        let ui = FsCodec.Union.Info.get typeof<'T>
-        let tag = ui.tagReader value
-        let case = ui.cases[tag]
-
         writer.WriteStartObject()
-        let u = UnionInfo.get typeof<'T>
-        let unionOptions = getOptions u
-        writer.WritePropertyName(unionOptions.Discriminator)
-        writer.WriteStringValue(case.Name)
-        let fieldValues = u.fieldReader[tag] value
-        let fieldInfos = case.GetFields()
-        for fieldInfo, fieldValue in Seq.zip fieldInfos fieldValues do
+        writer.WritePropertyName(converterOptions.DiscriminatorPropName)
+        let case = info.getCase value
+        writer.WriteStringValue(case.name)
+        let fieldValues = case.deconstruct value
+        for fieldInfo, fieldValue in Seq.zip case.fields fieldValues do
             if fieldValue <> null || options.DefaultIgnoreCondition <> Serialization.JsonIgnoreCondition.Always then
                 let element = JsonSerializer.SerializeToElement(fieldValue, fieldInfo.PropertyType, options)
-                if fieldInfos.Length = 1 && FSharpType.IsRecord(fieldInfo.PropertyType, true) then
+                if case.fields.Length = 1 && FSharpType.IsRecord(fieldInfo.PropertyType, true) then
                     // flatten the record properties into the same JSON object as the discriminator
                     for prop in element.EnumerateObject() do
                         prop.WriteTo writer
@@ -75,36 +47,31 @@ type UnionConverter<'T>() =
                     element.WriteTo writer
         writer.WriteEndObject()
 
-    override _.Read(reader, t : Type, options) =
+    override _.Read(reader, t: Type, options) =
         if reader.TokenType <> JsonTokenType.StartObject then
             sprintf "Unexpected token when reading Union: %O" reader.TokenType |> JsonException |> raise
         use document = JsonDocument.ParseValue &reader
-        let u = UnionInfo.get typeof<'T>
-        let ui = FsCodec.Union.Info.get typeof<'T>
-        let unionOptions = getOptions u
         let element = document.RootElement
 
-        let targetCaseTag =
-            let inputCaseNameValue = element.GetProperty unionOptions.Discriminator |> string
-            let findCaseNamed x = ui.cases |> Array.tryFindIndex (fun case -> case.Name = x)
-            match findCaseNamed inputCaseNameValue, unionOptions.CatchAllCase  with
-            | None, None ->
+        let case =
+            let inputCaseNameValue = element.GetProperty converterOptions.DiscriminatorPropName |> string
+            let findCaseNamed x = FsCodec.Union.Info.tryFindCaseWithName info ((=) x)
+            match findCaseNamed inputCaseNameValue, converterOptions.CatchAllCase  with
+            | None, null ->
                 sprintf "No case defined for '%s', and no catchAllCase nominated for '%s' on type '%s'"
                     inputCaseNameValue typeof<UnionConverter<_>>.Name t.FullName |> invalidOp
-            | Some foundIndex, _ -> foundIndex
-            | None, Some catchAllCaseName ->
+            | Some c, _ -> c
+            | None, catchAllCaseName ->
                 match findCaseNamed catchAllCaseName with
                 | None ->
                     sprintf "No case defined for '%s', nominated catchAllCase: '%s' not found in type '%s'"
                         inputCaseNameValue catchAllCaseName t.FullName |> invalidOp
-                | Some foundIndex -> foundIndex
-
-        let targetCaseFields, targetCaseCtor = ui.cases[targetCaseTag].GetFields(), ui.caseConstructor[targetCaseTag]
+                | Some c -> c
         let ctorArgs =
-            [| for fieldInfo in targetCaseFields ->
-                let t = fieldInfo.PropertyType
+            [| for fieldInfo in case.fields ->
+                let ft = fieldInfo.PropertyType
                 let targetEl =
-                    if targetCaseFields.Length = 1 && (t = typeof<JsonElement> || FSharpType.IsRecord(t, true)) then element
+                    if case.fields.Length = 1 && (ft = typeof<JsonElement> || FSharpType.IsRecord(ft, true)) then element
                     else let _found, el = element.TryGetProperty fieldInfo.Name in el
-                JsonSerializer.Deserialize(targetEl, t, options) |]
-        targetCaseCtor ctorArgs :?> 'T
+                JsonSerializer.Deserialize(targetEl, ft, options) |]
+        case.construct ctorArgs :?> 'T

--- a/src/FsCodec.SystemTextJson/UnionOrTypeSafeEnumConverterFactory.fs
+++ b/src/FsCodec.SystemTextJson/UnionOrTypeSafeEnumConverterFactory.fs
@@ -9,6 +9,7 @@ type internal ConverterActivator = delegate of unit -> JsonConverter
 type UnionOrTypeSafeEnumConverterFactory(typeSafeEnum, union) =
     inherit JsonConverterFactory()
 
+    static let hasConverterAttribute = memoize (fun (t: Type) -> t.IsDefined(typeof<JsonConverterAttribute>, true))
     let isIntrinsic (t: Type) =
         t.IsGenericType
         && (let gtd = t.GetGenericTypeDefinition() in gtd = typedefof<option<_>> || gtd = typedefof<list<_>>)
@@ -16,7 +17,7 @@ type UnionOrTypeSafeEnumConverterFactory(typeSafeEnum, union) =
     override _.CanConvert(t: Type) =
         not (isIntrinsic t)
         && FsCodec.Union.isUnion t
-        && not (UnionInfo.hasConverterAttribute t)
+        && not (hasConverterAttribute t)
         && ((typeSafeEnum && union)
             || typeSafeEnum = FsCodec.Union.isNullary t)
 

--- a/src/FsCodec.SystemTextJson/UnionOrTypeSafeEnumConverterFactory.fs
+++ b/src/FsCodec.SystemTextJson/UnionOrTypeSafeEnumConverterFactory.fs
@@ -13,16 +13,16 @@ type UnionOrTypeSafeEnumConverterFactory(typeSafeEnum, union) =
         t.IsGenericType
         && (let gtd = t.GetGenericTypeDefinition() in gtd = typedefof<option<_>> || gtd = typedefof<list<_>>)
 
-    override _.CanConvert(t : Type) =
+    override _.CanConvert(t: Type) =
         not (isIntrinsic t)
-        && Union.isUnion t
-        && not (Union.unionHasJsonConverterAttribute t)
+        && FsCodec.Union.isUnion t
+        && not (UnionInfo.hasConverterAttribute t)
         && ((typeSafeEnum && union)
-            || typeSafeEnum = Union.hasOnlyNullaryCases t)
+            || typeSafeEnum = FsCodec.Union.isNullary t)
 
-    override _.CreateConverter(typ, _options) =
-        let openConverterType = if Union.hasOnlyNullaryCases typ then typedefof<TypeSafeEnumConverter<_>> else typedefof<UnionConverter<_>>
-        let constructor = openConverterType.MakeGenericType(typ).GetConstructors() |> Array.head
+    override _.CreateConverter(t, _options) =
+        let openConverterType = if FsCodec.Union.isNullary t then typedefof<TypeSafeEnumConverter<_>> else typedefof<UnionConverter<_>>
+        let constructor = openConverterType.MakeGenericType(t).GetConstructors() |> Array.head
         let newExpression = Expression.New(constructor)
         let lambda = Expression.Lambda(typeof<ConverterActivator>, newExpression)
 

--- a/src/FsCodec/FsCodec.fsproj
+++ b/src/FsCodec/FsCodec.fsproj
@@ -9,6 +9,8 @@
     <Compile Include="Codec.fs" />
     <Compile Include="StreamId.fs" />
     <Compile Include="StreamName.fs" />
+    <Compile Include="Union.fs" />
+    <Compile Include="TypeSafeEnum.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FsCodec/TypeSafeEnum.fs
+++ b/src/FsCodec/TypeSafeEnum.fs
@@ -1,0 +1,38 @@
+﻿/// Utilities for working with F# DUs that have no bodies (i.e. pass both the <c>Union.isUnion</c> and <c>Union.isNullary</c> tests)
+module FsCodec.TypeSafeEnum
+
+open System
+open System.Collections.Generic
+open System.ComponentModel
+
+let isTypeSafeEnum t = Union.isUnion t && Union.isNullary t
+
+[<EditorBrowsable(EditorBrowsableState.Never)>]
+let tryParseTF (t: Type) =
+    let u = Union.Info.get t
+    fun predicate ->
+        u.cases
+        |> Array.tryFindIndex (fun c -> predicate c.Name)
+        |> Option.map (fun tag -> u.caseConstructor[tag] Array.empty)
+[<EditorBrowsable(EditorBrowsableState.Never)>]
+let parseTF (t: Type) predicate =
+    let p = tryParseTF t
+    fun (str: string) ->
+        match p (predicate str) with
+        | Some e -> e
+        | None ->
+            // Keep exception compat, but augment with a meaningful message.
+            raise (KeyNotFoundException(sprintf "Could not find case '%s' for type '%s'" str t.FullName))
+[<EditorBrowsable(EditorBrowsableState.Never)>]
+let parseT (t: Type) = parseTF t (=)
+
+let tryParseF<'T> =
+    let p = tryParseTF typeof<'T>
+    fun f str -> p (f str) |> Option.map (fun e -> e :?> 'T)
+let tryParse<'T> = tryParseF<'T> (=)
+let parseF<'T> f =
+    let p = parseTF typeof<'T> f
+    fun (str: string) -> p str :?> 'T
+let parse<'T> = parseF<'T> (=)
+
+let toString<'t> = Union.caseName<'t>

--- a/src/FsCodec/Union.fs
+++ b/src/FsCodec/Union.fs
@@ -1,0 +1,42 @@
+module FsCodec.Union
+
+open System
+open System.ComponentModel
+open Microsoft.FSharp.Reflection
+
+/// Provides a thread-safe memoization wrapper for supplied function
+let private memoize: ('T -> 'S) -> 'T -> 'S =
+    fun f ->
+        let cache = System.Collections.Concurrent.ConcurrentDictionary<'T, 'S>()
+        fun t -> cache.GetOrAdd(t, f)
+
+[<NoComparison; NoEquality; EditorBrowsable(EditorBrowsableState.Never)>]
+type Info =
+    {   cases: UnionCaseInfo[]
+        tagReader: obj -> int
+        caseConstructor: (obj[] -> obj)[] }
+[<EditorBrowsable(EditorBrowsableState.Never)>]
+module Info =
+    let get: Type -> Info = memoize (fun t ->
+        let cases = FSharpType.GetUnionCases(t, true)
+        {   cases = cases
+            tagReader = FSharpValue.PreComputeUnionTagReader(t, true)
+            caseConstructor = cases |> Array.map (fun c -> FSharpValue.PreComputeUnionConstructor(c, true)) })
+
+/// Determines whether the type is a Union
+let isUnion: Type -> bool = memoize (fun t -> FSharpType.IsUnion(t, true))
+
+/// Determines whether a union has no bodies (and hence can use a TypeSafeEnum.parse and/or TypeSafeEnumConverter)
+let isNullary (t: Type) =
+    let u = Info.get t
+    u.cases |> Array.forall (fun case -> case.GetFields().Length = 0)
+
+[<EditorBrowsable(EditorBrowsableState.Never)>]
+let caseNameT t =
+    let u = Info.get t
+    fun x -> u.cases[u.tagReader x].Name
+
+/// Yields the case name for a given value, regardless of whether it <c>isNullary</c> or not.
+let caseName<'t> =
+    let u = Info.get typeof<'t>
+    fun (x: 't) -> u.cases[u.tagReader x].Name

--- a/src/FsCodec/Union.fs
+++ b/src/FsCodec/Union.fs
@@ -1,42 +1,45 @@
 module FsCodec.Union
 
+open Microsoft.FSharp.Reflection
 open System
 open System.ComponentModel
-open Microsoft.FSharp.Reflection
 
-/// Provides a thread-safe memoization wrapper for supplied function
-let private memoize: ('T -> 'S) -> 'T -> 'S =
-    fun f ->
-        let cache = System.Collections.Concurrent.ConcurrentDictionary<'T, 'S>()
-        fun t -> cache.GetOrAdd(t, f)
+let private memoize (f: 'T -> 'S): 'T -> 'S =
+    let cache = System.Collections.Concurrent.ConcurrentDictionary<'T, 'S>()
+    fun t -> cache.GetOrAdd(t, f)
 
-[<NoComparison; NoEquality; EditorBrowsable(EditorBrowsableState.Never)>]
-type Info =
-    {   cases: UnionCaseInfo[]
-        tagReader: obj -> int
-        caseConstructor: (obj[] -> obj)[] }
+[<Struct; NoComparison; NoEquality; EditorBrowsable(EditorBrowsableState.Never)>]
+type CaseInfo = { name: string; fields: System.Reflection.PropertyInfo[]; construct: obj[] -> obj; deconstruct: obj -> obj[] }
+
+[<Struct; NoComparison; NoEquality; EditorBrowsable(EditorBrowsableState.Never)>]
+type Info = { cases: CaseInfo[]; getCase: obj -> CaseInfo }
+
 [<EditorBrowsable(EditorBrowsableState.Never)>]
 module Info =
     let get: Type -> Info = memoize (fun t ->
-        let cases = FSharpType.GetUnionCases(t, true)
-        {   cases = cases
-            tagReader = FSharpValue.PreComputeUnionTagReader(t, true)
-            caseConstructor = cases |> Array.map (fun c -> FSharpValue.PreComputeUnionConstructor(c, true)) })
+        let cases = FSharpType.GetUnionCases(t, true) |> Array.map (fun i ->
+             {  name = i.Name
+                fields = i.GetFields()
+                construct = FSharpValue.PreComputeUnionConstructor(i, true)
+                deconstruct = FSharpValue.PreComputeUnionReader(i, true) })
+        let getTag = FSharpValue.PreComputeUnionTagReader(t, true)
+        let getCase value = Array.item (getTag value) cases
+        { cases = cases; getCase = getCase })
+    let tryFindCaseWithName u predicate = u.cases |> Array.tryFind (fun c -> predicate c.name)
+    let private caseValues: Type -> obj[] = memoize (fun t -> (get t).cases |> Array.map (fun c -> c.construct Array.empty))
+    let tryFindCaseValueWithName t =
+        let u = get t
+        let caseValue = let values = caseValues t in fun i -> values[i]
+        fun predicate -> u.cases |> Array.tryFindIndex (fun c -> predicate c.name) |> Option.map caseValue
 
 /// Determines whether the type is a Union
 let isUnion: Type -> bool = memoize (fun t -> FSharpType.IsUnion(t, true))
 
 /// Determines whether a union has no bodies (and hence can use a TypeSafeEnum.parse and/or TypeSafeEnumConverter)
-let isNullary (t: Type) =
-    let u = Info.get t
-    u.cases |> Array.forall (fun case -> case.GetFields().Length = 0)
+let isNullary (t: Type) = let u = Info.get t in u.cases |> Array.forall (fun case -> case.fields.Length = 0)
 
 [<EditorBrowsable(EditorBrowsableState.Never)>]
-let caseNameT t =
-    let u = Info.get t
-    fun x -> u.cases[u.tagReader x].Name
+let caseNameT (t: Type) (x: obj) = ((Info.get t).getCase x).name
 
 /// Yields the case name for a given value, regardless of whether it <c>isNullary</c> or not.
-let caseName<'t> =
-    let u = Info.get typeof<'t>
-    fun (x: 't) -> u.cases[u.tagReader x].Name
+let caseName<'t>(x: 't) = ((Info.get typeof<'t>).getCase x).name

--- a/tests/FsCodec.NewtonsoftJson.Tests/Examples.fsx
+++ b/tests/FsCodec.NewtonsoftJson.Tests/Examples.fsx
@@ -93,11 +93,11 @@ type OutcomeWithOther = Joy | Pain | Misery | Other
 and OutcomeWithCatchAllConverter() =
     inherit JsonIsomorphism<OutcomeWithOther, string>()
     override _.Pickle v =
-        TypeSafeEnum.toString v
+        FsCodec.TypeSafeEnum.toString v
 
     override _.UnPickle json =
         json
-        |> TypeSafeEnum.tryParse<OutcomeWithOther>
+        |> FsCodec.TypeSafeEnum.tryParse<OutcomeWithOther>
         |> Option.defaultValue Other
 
 type Message2 = { name: string option; outcome: OutcomeWithOther }

--- a/tests/FsCodec.SystemTextJson.Tests/AutoUnionTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/AutoUnionTests.fs
@@ -1,5 +1,6 @@
 module FsCodec.SystemTextJson.Tests.AutoUnionTests
 
+open FsCodec
 open FsCodec.SystemTextJson
 open Swensen.Unquote
 

--- a/tests/FsCodec.SystemTextJson.Tests/Examples.fsx
+++ b/tests/FsCodec.SystemTextJson.Tests/Examples.fsx
@@ -95,11 +95,11 @@ type OutcomeWithOther = Joy | Pain | Misery | Other
 and OutcomeWithCatchAllConverter() =
     inherit JsonIsomorphism<OutcomeWithOther, string>()
     override _.Pickle v =
-        TypeSafeEnum.toString v
+        FsCodec.TypeSafeEnum.toString v
 
     override _.UnPickle json =
         json
-        |> TypeSafeEnum.tryParse<OutcomeWithOther>
+        |> FsCodec.TypeSafeEnum.tryParse<OutcomeWithOther>
         |> Option.defaultValue Other
 
 type Message2 = { name: string option; outcome: OutcomeWithOther }

--- a/tests/FsCodec.SystemTextJson.Tests/TypeSafeEnumConverterTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/TypeSafeEnumConverterTests.fs
@@ -11,11 +11,15 @@ open Xunit
 type Outcome = Joy | Pain | Misery
 
 let [<Fact>] happy () =
+    let oic (x: string) y = x.Equals(y, StringComparison.OrdinalIgnoreCase)
     test <@ box Joy = TypeSafeEnum.parseT typeof<Outcome> "Joy" @>
     test <@ Joy = TypeSafeEnum.parse "Joy" @>
+    test <@ Joy = TypeSafeEnum.parseF oic "JOY" @>
     test <@ box Joy = TypeSafeEnum.parseT typeof<Outcome> "Joy"  @>
+    test <@ box Joy = TypeSafeEnum.parseTF typeof<Outcome> oic "Joy"  @>
     test <@ None = TypeSafeEnum.tryParse<Outcome> "Wat" @>
     raises<KeyNotFoundException> <@ TypeSafeEnum.parse<Outcome> "Wat" @>
+    raises<KeyNotFoundException> <@ TypeSafeEnum.parseF<Outcome> oic "Wat" @>
 
     let serdesWithOutcomeConverter = Options.Create(TypeSafeEnumConverter<Outcome>()) |> Serdes
     test <@ Joy = serdesWithOutcomeConverter.Deserialize "\"Joy\"" @>

--- a/tests/FsCodec.SystemTextJson.Tests/TypeSafeEnumConverterTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/TypeSafeEnumConverterTests.fs
@@ -1,5 +1,6 @@
 module FsCodec.SystemTextJson.Tests.TypeSafeEnumConverterTests
 
+open FsCodec
 open FsCodec.SystemTextJson
 open System
 open System.Collections.Generic


### PR DESCRIPTION
The `TypeSafeEnum` helper class initially lived in NewtonsoftJson as it was an internal impl detail of the converter
The STJ reimpl did some optimisation etc while following the same API

This comes to a head on the consumption side if you need to programmatically manipulate Union and/or TypeSafeEnum generically; abusing `FsCodec.SystemTextJson.TypeSafeEnum.toString` makes things very confusing.