### PR TITLE
fix!: Change default Event timestamp to UtcNow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Fixed
 
+- `Core.Codec`: Changed default timestamp to `DateTime.UtcNow` as per docs (was: `DateTime.Now`) [#104](https://github.com/jet/FsCodec/pull/104)
+
 <a name="3.0.0-rc.11"></a>
 ## [3.0.0-rc.11] - 2023-8-25
 

--- a/src/FsCodec.Box/CoreCodec.fs
+++ b/src/FsCodec.Box/CoreCodec.fs
@@ -73,7 +73,7 @@ type Codec private () =
         let down context union =
             let struct (c, m, t) = down.Invoke union
             let struct (m', eventId, correlationId, causationId) = mapCausation.Invoke(context, m)
-            struct (c, m', eventId, correlationId, causationId, match t with ValueSome t -> t | ValueNone -> DateTimeOffset.Now)
+            struct (c, m', eventId, correlationId, causationId, match t with ValueSome t -> t | ValueNone -> DateTimeOffset.UtcNow)
         Codec.Create(encoder, up = up, down = down, ?rejectNullaryCases = rejectNullaryCases)
 
     /// <summary>Generate an <code>IEventCodec</code> using the supplied <c>encoder</c>.<br/>


### PR DESCRIPTION
Though it arguably does not matter due to the Offset being included in the stored form, it's best for this to match the documentation (yes, despite it having been this way for some time)