### PR TITLE
fix: Update min Newtonsoft dependency to 13.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 ### Changed
 
-- `NewtonsoftJson`: Upped minimum `Newtonsoft.Json` version to `13.0.3` per [GitHub advisory database](https://www.nuget.org/packages/newtonsoft.json/11.0.2)
+- `NewtonsoftJson`: Upped minimum `Newtonsoft.Json` version to `13.0.3` per [GitHub advisory database](https://www.nuget.org/packages/newtonsoft.json/11.0.2) [#109](https://github.com/jet/FsCodec/pull/109)
 
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- `NewtonsoftJson`: Upped minimum `Newtonsoft.Json` version to `13.0.3` per [GitHub advisory database](https://www.nuget.org/packages/newtonsoft.json/11.0.2)
+
 ### Removed
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The components within this repository are delivered as multi-targeted Nuget pack
 - [![Newtonsoft.Json Codec NuGet](https://img.shields.io/nuget/v/FsCodec.NewtonsoftJson.svg)](https://www.nuget.org/packages/FsCodec.NewtonsoftJson/) `FsCodec.NewtonsoftJson`: As described in [a scheme for the serializing Events modelled as an F# Discriminated Union](https://eiriktsarpalis.wordpress.com/2018/10/30/a-contract-pattern-for-schemaless-datastores/), enabled tagging of F# Discriminated Union cases in a versionable manner with low-dependencies using [TypeShape](https://github.com/eiriktsarpalis/TypeShape)'s [`UnionContractEncoder`](https://eiriktsarpalis.wordpress.com/2018/10/30/a-contract-pattern-for-schemaless-datastores)
   - Uses the ubiquitous [`Newtonsoft.Json`](https://github.com/JamesNK/Newtonsoft.Json) library to serialize the event bodies.
   - Provides relevant Converters for common non-primitive types prevalent in F#
-  - [depends](https://www.fuget.org/packages/FsCodec.NewtonsoftJson) on `FsCodec.Box`, `Newtonsoft.Json >= 11.0.2`, `Microsoft.IO.RecyclableMemoryStream >= 2.2.0`, `System.Buffers >= 4.5.1`
+  - [depends](https://www.fuget.org/packages/FsCodec.NewtonsoftJson) on `FsCodec.Box`, `Newtonsoft.Json >= 13.0.3`, `Microsoft.IO.RecyclableMemoryStream >= 2.2.0`, `System.Buffers >= 4.5.1`
 - [![System.Text.Json Codec NuGet](https://img.shields.io/nuget/v/FsCodec.SystemTextJson.svg)](https://www.nuget.org/packages/FsCodec.SystemTextJson/) `FsCodec.SystemTextJson`: See [#38](https://github.com/jet/FsCodec/pulls/38): drop in replacement that allows one to retarget from `Newtonsoft.Json` to the .NET Core >= v 3.0 default serializer: `System.Text.Json`, solely by changing the referenced namespace.
   - [depends](https://www.fuget.org/packages/FsCodec.SystemTextJson) on `FsCodec.Box`, `System.Text.Json >= 6.0.1`,
 
@@ -50,7 +50,7 @@ The concrete implementations implement common type/member/function signatures an
 
 ## `Codec`
 
-[`FsCodec.NewtonsoftJson/SystemTextJson.Codec`](https://github.com/jet/FsCodec/blob/master/src/FsCodec.NewtonsoftJson/Codec.fs) provides an implementation of `IEventCodec` as described in [a scheme for the serializing Events modelled as an F# Discriminated Union](https://eiriktsarpalis.wordpress.com/2018/10/30/a-contract-pattern-for-schemaless-datastores/). This yields a clean yet versionable way of managing the roundtripping events based on a contract inferred from an F# Discriminated Union Type using `Newtonsoft.Json >= 11.0.2` / `System.Text.Json` to serialize the bodies.
+[`FsCodec.NewtonsoftJson/SystemTextJson.Codec`](https://github.com/jet/FsCodec/blob/master/src/FsCodec.NewtonsoftJson/Codec.fs) provides an implementation of `IEventCodec` as described in [a scheme for the serializing Events modelled as an F# Discriminated Union](https://eiriktsarpalis.wordpress.com/2018/10/30/a-contract-pattern-for-schemaless-datastores/). This yields a clean yet versionable way of managing the roundtripping events based on a contract inferred from an F# Discriminated Union Type using `Newtonsoft.Json >= 13.0.3` / `System.Text.Json` to serialize the bodies.
 
 ## Converters: `Newtonsoft.Json.Converter`s / `System.Text.Json.Serialization.JsonConverter`s
 

--- a/src/FsCodec.NewtonsoftJson/FsCodec.NewtonsoftJson.fsproj
+++ b/src/FsCodec.NewtonsoftJson/FsCodec.NewtonsoftJson.fsproj
@@ -21,7 +21,7 @@
     <PackageReference Include="FSharp.Core" Version="4.5.4" />
 
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
   </ItemGroup>
 


### PR DESCRIPTION
FsCodec is only a library, and the host application ultimately controls the specific JSON.NET version. As such, it can be argued that the minimum is not relevant.

However, we're about to roll to v3, so pulls in a version of a library [that's been flagged](https://www.nuget.org/packages/newtonsoft.json/11.0.2) is problematic as the default behavior for an app using the library via NuGet will be to take the minimum required

- Originally flagged (and intentionally avoided on the 'the host owns it' basis mentioned in the overview) in #89 