### PR TITLE
fix!: Workaround for JamesNK/Newtonsoft.Json#862

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Changed
 
 - `NewtonsoftJson`: Upped minimum `Newtonsoft.Json` version to `13.0.3` per [GitHub advisory database](https://www.nuget.org/packages/newtonsoft.json/11.0.2) [#109](https://github.com/jet/FsCodec/pull/109)
+- `Newtonsoft.Options`: Change all settings (inc `CreateDefault`) to set `DateParseHandling = DateParseHandling.None` in order to work around [the hare-brained default](https://github.com/JamesNK/Newtonsoft.Json/issues/862) [#108](https://github.com/jet/FsCodec/pull/108)
 
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Changed
 
 - `NewtonsoftJson`: Upped minimum `Newtonsoft.Json` version to `13.0.3` per [GitHub advisory database](https://www.nuget.org/packages/newtonsoft.json/11.0.2) [#109](https://github.com/jet/FsCodec/pull/109)
-- `Newtonsoft.Options`: Change all settings (inc `CreateDefault`) to set `DateParseHandling = DateParseHandling.None` in order to work around [the hare-brained default](https://github.com/JamesNK/Newtonsoft.Json/issues/862) [#108](https://github.com/jet/FsCodec/pull/108)
+- `NewtonsoftJson.Options`: Change all settings (inc `CreateDefault`) to set `DateParseHandling = DateParseHandling.None` in order to work around [the hare-brained default](https://github.com/JamesNK/Newtonsoft.Json/issues/862) [#110](https://github.com/jet/FsCodec/pull/110)
 
 ### Removed
 ### Fixed

--- a/src/FsCodec.NewtonsoftJson/Options.fs
+++ b/src/FsCodec.NewtonsoftJson/Options.fs
@@ -14,6 +14,7 @@ type Options private () =
     static member val Default : JsonSerializerSettings = Options.Create()
 
     /// Creates a default set of serializer settings used by Json serialization. When used with no args, same as JsonSerializerSettings.CreateDefault()
+    /// With one difference - it inhibits the JSON.NET out of the box parsing of strings that look like dates (see https://github.com/JamesNK/Newtonsoft.Json/issues/862)
     static member CreateDefault
         (   [<Optional; ParamArray>] converters : JsonConverter[],
             // Use multi-line, indented formatting when serializing JSON; defaults to false.
@@ -38,6 +39,7 @@ type Options private () =
             Converters = converters,
             DateTimeZoneHandling = DateTimeZoneHandling.Utc, // Override default of RoundtripKind
             DateFormatHandling = DateFormatHandling.IsoDateFormat, // Pin Json.Net claimed default
+            DateParseHandling = DateParseHandling.None, // Override hare-brained default of DateTime per https://github.com/JamesNK/Newtonsoft.Json/issues/862
             Formatting = (if indent then Formatting.Indented else Formatting.None),
             MissingMemberHandling = (if errorOnMissing then MissingMemberHandling.Error else MissingMemberHandling.Ignore),
             NullValueHandling = (if ignoreNulls then NullValueHandling.Ignore else NullValueHandling.Include))


### PR DESCRIPTION
Change `Options.CreateDefault` (and `.Create`, and `.Default` etc) to avoid falling into JNK's epic trolling default trap in https://github.com/JamesNK/Newtonsoft.Json/issues/862