### PR TITLE
RejectNullConverter PoC attempt

### DIFF
--- a/src/FsCodec.SystemTextJson/FsCodec.SystemTextJson.fsproj
+++ b/src/FsCodec.SystemTextJson/FsCodec.SystemTextJson.fsproj
@@ -10,6 +10,7 @@
     <Compile Include="TypeSafeEnumConverter.fs" />
     <Compile Include="RejectNullStringConverter.fs" />
     <Compile Include="UnionOrTypeSafeEnumConverterFactory.fs" />
+    <Compile Include="RejectNullConverter.fs" />
     <Compile Include="Options.fs" />
     <Compile Include="Serdes.fs" />
     <Compile Include="Codec.fs" />
@@ -22,7 +23,7 @@
 
     <PackageReference Include="FSharp.Core" Version="4.5.4" />
 
-    <PackageReference Include="System.Text.Json" Version="6.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FsCodec.SystemTextJson/Options.fs
+++ b/src/FsCodec.SystemTextJson/Options.fs
@@ -60,7 +60,10 @@ type Options private () =
             [<Optional; DefaultParameterValue(null)>] ?autoUnionToJsonObject: bool,
             // Apply <c>RejectNullStringConverter</c> in order to have serialization throw on <c>null</c> strings.
             // Use <c>string option</c> to represent strings that can potentially be <c>null</c>.
-            [<Optional; DefaultParameterValue(null)>] ?rejectNullStrings: bool) =
+            [<Optional; DefaultParameterValue(null)>] ?rejectNullStrings: bool,
+            // Apply <c>RejectNullConverter</c> in order to have serialization throw on <c>null</c> on <c>null</c> or missing <c>list</c> or <c>Set</c> values.
+            // Wrap the type in <c>option</c> to represent values that can potentially be <c>null</c> or missing
+            [<Optional; DefaultParameterValue(null)>] ?rejectNull: bool) =
         let autoTypeSafeEnumToJsonString = defaultArg autoTypeSafeEnumToJsonString false
         let autoUnionToJsonObject = defaultArg autoUnionToJsonObject false
         let rejectNullStrings = defaultArg rejectNullStrings false
@@ -68,6 +71,7 @@ type Options private () =
         Options.CreateDefault(
             converters = [|
                 if rejectNullStrings then RejectNullStringConverter()
+                if defaultArg rejectNull false then RejectNullConverterFactory()
                 if autoTypeSafeEnumToJsonString || autoUnionToJsonObject then
                     UnionOrTypeSafeEnumConverterFactory(typeSafeEnum = autoTypeSafeEnumToJsonString, union = autoUnionToJsonObject)
                 if converters <> null then yield! converters

--- a/src/FsCodec.SystemTextJson/RejectNullConverter.fs
+++ b/src/FsCodec.SystemTextJson/RejectNullConverter.fs
@@ -1,0 +1,42 @@
+namespace FsCodec.SystemTextJson
+
+open System
+open System.Linq.Expressions
+open System.Text.Json
+open System.Text.Json.Serialization
+
+type RejectNullConverter<'T>() =
+    inherit System.Text.Json.Serialization.JsonConverter<'T>()
+
+    static let defaultConverter = JsonSerializerOptions.Default.GetConverter(typeof<'T>) :?> JsonConverter<'T>
+    let msg () = sprintf "Expected value, got null. When rejectNull is true you must explicitly wrap optional %s values in an 'option'" typeof<'T>.Name
+
+    override _.HandleNull = true
+
+    override _.Read(reader, typeToConvert, options) =
+        if reader.TokenType = JsonTokenType.Null then msg () |> nullArg else
+        defaultConverter.Read(&reader, typeToConvert, options)
+        // Pretty sure the above is the correct approach (and this unsurprisingly loops, blowing the stack)
+        // JsonSerializer.Deserialize(&reader, typeToConvert, options) :?> 'T
+
+    override _.Write(writer, value, options) =
+        if value |> box |> isNull then msg () |> nullArg
+        defaultConverter.Write(writer, value, options)
+        // JsonSerializer.Serialize<'T>(writer, value, options)
+
+type RejectNullConverterFactory(predicate) =
+    inherit JsonConverterFactory()
+    new() =
+        RejectNullConverterFactory(fun (t: Type) ->
+            t.IsGenericType
+            && let gtd = t.GetGenericTypeDefinition() in gtd = typedefof<Set<_>> || gtd = typedefof<list<_>>)
+    override _.CanConvert(t: Type) = predicate t
+
+    override _.CreateConverter(t, _options) =
+        let openConverterType = typedefof<RejectNullConverter<_>>
+        let constructor = openConverterType.MakeGenericType(t).GetConstructors() |> Array.head
+        let newExpression = Expression.New(constructor)
+        let lambda = Expression.Lambda(typeof<ConverterActivator>, newExpression)
+
+        let activator = lambda.Compile() :?> ConverterActivator
+        activator.Invoke()

--- a/src/FsCodec.SystemTextJson/RejectNullConverter.fs
+++ b/src/FsCodec.SystemTextJson/RejectNullConverter.fs
@@ -1,20 +1,23 @@
 namespace FsCodec.SystemTextJson
 
 open System
-open System.Linq.Expressions
 open System.Text.Json
 open System.Text.Json.Serialization
 
 type RejectNullConverter<'T>() =
     inherit System.Text.Json.Serialization.JsonConverter<'T>()
 
-    static let defaultConverter = JsonSerializerOptions.Default.GetConverter(typeof<'T>) :?> JsonConverter<'T>
+    let defaultConverter = JsonSerializerOptions.Default.GetConverter(typeof<'T>) :?> JsonConverter<'T>
     let msg () = sprintf "Expected value, got null. When rejectNull is true you must explicitly wrap optional %s values in an 'option'" typeof<'T>.Name
 
     override _.HandleNull = true
 
     override _.Read(reader, typeToConvert, options) =
         if reader.TokenType = JsonTokenType.Null then msg () |> nullArg else
+        // PROBLEM: Fails with NRE when RejectNullConverter delegates to Default list<int> Converter
+        // System.NullReferenceException
+        //  at System.Text.Json.Serialization.JsonCollectionConverter`2.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, TCollection& value)
+        // https://github.com/dotnet/runtime/issues/50205 via https://github.com/jet/FsCodec/pull/112#issuecomment-1907633798
         defaultConverter.Read(&reader, typeToConvert, options)
         // Pretty sure the above is the correct approach (and this unsurprisingly loops, blowing the stack)
         // JsonSerializer.Deserialize(&reader, typeToConvert, options) :?> 'T
@@ -26,17 +29,8 @@ type RejectNullConverter<'T>() =
 
 type RejectNullConverterFactory(predicate) =
     inherit JsonConverterFactory()
-    new() =
-        RejectNullConverterFactory(fun (t: Type) ->
-            t.IsGenericType
-            && let gtd = t.GetGenericTypeDefinition() in gtd = typedefof<Set<_>> || gtd = typedefof<list<_>>)
+    static let isListOrSet (t: Type) = t.IsGenericType && let g = t.GetGenericTypeDefinition() in g = typedefof<Set<_>> || g = typedefof<list<_>>
+    new() = RejectNullConverterFactory(isListOrSet)
+
     override _.CanConvert(t: Type) = predicate t
-
-    override _.CreateConverter(t, _options) =
-        let openConverterType = typedefof<RejectNullConverter<_>>
-        let constructor = openConverterType.MakeGenericType(t).GetConstructors() |> Array.head
-        let newExpression = Expression.New(constructor)
-        let lambda = Expression.Lambda(typeof<ConverterActivator>, newExpression)
-
-        let activator = lambda.Compile() :?> ConverterActivator
-        activator.Invoke()
+    override _.CreateConverter(t, _options) = typedefof<RejectNullConverter<_>>.MakeGenericType(t).GetConstructors().[0].Invoke[||] :?> _

--- a/tests/FsCodec.SystemTextJson.Tests/SerdesTests.fs
+++ b/tests/FsCodec.SystemTextJson.Tests/SerdesTests.fs
@@ -80,7 +80,7 @@ let [<Fact>] ``RejectNullStringConverter rejects null strings`` () =
     let value = { c = 1; d = null }
     raises<ArgumentNullException> <@ serdes.Serialize value @>
 
-type WithList = { x: int; y: list<int> }
+type WithList = { x: int; y: list<int>; z: Set<int> }
 
 let [<Fact>] ``RejectNullConverter rejects null lists and Sets`` () =
 #if false // requires WithList to be CLIMutable, which would be a big imposition
@@ -93,18 +93,28 @@ let [<Fact>] ``RejectNullConverter rejects null lists and Sets`` () =
                     if pt.IsGenericType && (let gtd = pt.GetGenericTypeDefinition() in gtd = typedefof<list<_>> || gtd = typedefof<Set<_>>) then
                         p.IsRequired <- true)
     let serdes = Options.Create(TypeInfoResolver = tir) |> Serdes
+    raises<exn> <@ serdes.Deserialize<WithList> """{"x":0}""" @>
 #else
     let serdes = Options.Create(rejectNull = true) |> Serdes
-#endif
 
     // Fails with NRE when RejectNullConverter delegates to Default list<int> Converter
     // seems akin to https://github.com/dotnet/runtime/issues/86483
-    let res = serdes.Deserialize<WithList> """{"x":0,"y":[1]}"""
-    test <@ [1] = res.y @>
+    // let res = serdes.Deserialize<WithList> """{"x":0,"y":[1]}"""
+    // test <@ [1] = res.y @>
 
+    // PROBLEM: Doesn't raise
     raises<exn> <@ serdes.Deserialize<WithList> """{"x":0}""" @>
-    // PROBLEM: there doesn't seem to be a way to intercept explicitly passed nulls
+    // PROBLEM: doesnt raise - there doesn't seem to be a way to intercept explicitly passed nulls
     // raises<JsonException> <@ serdes.Deserialize<WithList> """{"x":0,"y":null}""" @>
+#endif
+
+#if false // I guess TypeShape is doing a reasaonable thing not propagating
+    // PROBLEM: TypeShape.Generic.exists does not call the predicate if the list or set is `null`
+    let res = serdes.Deserialize<WithList> """{"x":0}"""
+    let hasNullList = TypeShape.Generic.exists (fun (x: int list) -> obj.ReferenceEquals(x, null))
+    let hasNullSet = TypeShape.Generic.exists (fun (x: Set<int>) -> obj.ReferenceEquals(x, null))
+    test <@ hasNullList res && hasNullSet res @>
+#endif
 
 let [<Fact>] ``RejectNullStringConverter serializes strings correctly`` () =
     let serdes = Serdes(Options.Create(rejectNullStrings = true))


### PR DESCRIPTION
In the spirit of https://github.com/jet/FsCodec/pull/87 this attempts to guard against the read path producing `null` instances of `FSharpList<'T>` and `FSharpSet<'T>`.

However, while the docs suggest that this general approach should work, I've run aground with a `NullReferenceException` that seems similar to https://github.com/dotnet/runtime/issues/86483 when inspected in the debugger (`elementTypeInfo` is `null`)

```
System.NullReferenceException
Object reference not set to an instance of an object.
   at System.Text.Json.Serialization.JsonCollectionConverter`2.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, TCollection& value)
   at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value, Boolean& isPopulatedValue)
   at System.Text.Json.Serialization.JsonResumableConverter`1.Read(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options)
   at FsCodec.SystemTextJson.RejectNullConverter`1.Read(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options)
   ```