### PR TITLE
fix(JsonPicker, JsonIsomorphism, UnionConverter)!: Reduce greediness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- `BREAKING: JsonPickler/JsonIsomorphism/UnionConverter`: Reduced greediness of `Type` matching (only honors tags placed on the type being serialized, not parents) [#113](https://github.com/jet/FsCodec/pull/113)
+
 ### Removed
 ### Fixed
 

--- a/src/FsCodec.NewtonsoftJson/Pickler.fs
+++ b/src/FsCodec.NewtonsoftJson/Pickler.fs
@@ -1,34 +1,15 @@
 ﻿namespace FsCodec.NewtonsoftJson
 
 open Newtonsoft.Json
-open System
-
-[<AutoOpen>]
-module private Prelude =
-    let memoize (f: 'T -> 'S): 'T -> 'S =
-        let cache = new System.Collections.Concurrent.ConcurrentDictionary<'T, 'S>()
-        fun t -> cache.GetOrAdd(t, f)
 
 [<AbstractClass>]
 type JsonPickler<'T>() =
     inherit JsonConverter()
 
-    static let isMatchingType =
-        let rec isMatching = function
-            | [] -> false
-            | t :: _ when t = typeof<'T> -> true
-            | t :: tl ->
-                let tail =
-                    [ match t.BaseType with null -> () | bt -> yield bt
-                      yield! t.GetInterfaces()
-                      yield! tl ]
-                isMatching tail
-        memoize (fun t -> isMatching [t])
-
     abstract Write: writer: JsonWriter * serializer: JsonSerializer * source: 'T  -> unit
     abstract Read: reader: JsonReader * serializer: JsonSerializer -> 'T
 
-    override _.CanConvert t = isMatchingType t
+    override _.CanConvert t = t = typeof<'T>
     override _.CanRead = true
     override _.CanWrite = true
 

--- a/src/FsCodec.NewtonsoftJson/UnionConverter.fs
+++ b/src/FsCodec.NewtonsoftJson/UnionConverter.fs
@@ -3,7 +3,6 @@
 open Newtonsoft.Json
 open Newtonsoft.Json.Linq
 open System
-open System.Reflection
 
 [<NoComparison; NoEquality>]
 module private UnionInfo =
@@ -15,7 +14,7 @@ module private UnionInfo =
         || t.IsArray
         || (t.IsGenericType && let g = t.GetGenericTypeDefinition() in typedefof<Option<_>> = g || g.IsValueType) // Nullable<T>
 
-    let typeHasConverterAttribute = memoize (fun (t: Type) -> t.IsDefined(typeof<JsonConverterAttribute>))
+    let typeHasConverterAttribute = memoize (fun (t: Type) -> t.IsDefined(typeof<JsonConverterAttribute>, ``inherit`` = false))
     let typeIsUnionWithConverterAttribute = memoize (fun (t: Type) -> FsCodec.Union.isUnion t && typeHasConverterAttribute t)
 
     let propTypeRequiresConstruction (propertyType: Type) =
@@ -24,7 +23,7 @@ module private UnionInfo =
 
     /// Prepare arguments for the Case class ctor based on the kind of case and how F# maps that to a Type
     /// and/or whether we need to let json.net step in to convert argument types
-    let mapTargetCaseArgs (inputJObject: JObject) serializer: PropertyInfo[] -> obj [] = function
+    let mapTargetCaseArgs (inputJObject: JObject) serializer: System.Reflection.PropertyInfo[] -> obj [] = function
         | [| singleCaseArg |] when propTypeRequiresConstruction singleCaseArg.PropertyType ->
             [| inputJObject.ToObject(singleCaseArg.PropertyType, serializer) |]
         | multipleFieldsInCustomCaseType ->

--- a/src/FsCodec.NewtonsoftJson/UnionConverter.fs
+++ b/src/FsCodec.NewtonsoftJson/UnionConverter.fs
@@ -3,6 +3,7 @@
 open Newtonsoft.Json
 open Newtonsoft.Json.Linq
 open System
+open System.Reflection
 
 [<NoComparison; NoEquality>]
 module private UnionInfo =
@@ -14,7 +15,7 @@ module private UnionInfo =
         || t.IsArray
         || (t.IsGenericType && let g = t.GetGenericTypeDefinition() in typedefof<Option<_>> = g || g.IsValueType) // Nullable<T>
 
-    let typeHasConverterAttribute = memoize (fun (t: Type) -> t.IsDefined(typeof<JsonConverterAttribute>, ``inherit`` = false))
+    let typeHasConverterAttribute = memoize (fun (t: Type) -> t.IsDefined(typeof<JsonConverterAttribute>))
     let typeIsUnionWithConverterAttribute = memoize (fun (t: Type) -> FsCodec.Union.isUnion t && typeHasConverterAttribute t)
 
     let propTypeRequiresConstruction (propertyType: Type) =
@@ -23,7 +24,7 @@ module private UnionInfo =
 
     /// Prepare arguments for the Case class ctor based on the kind of case and how F# maps that to a Type
     /// and/or whether we need to let json.net step in to convert argument types
-    let mapTargetCaseArgs (inputJObject: JObject) serializer: System.Reflection.PropertyInfo[] -> obj [] = function
+    let mapTargetCaseArgs (inputJObject: JObject) serializer: PropertyInfo[] -> obj [] = function
         | [| singleCaseArg |] when propTypeRequiresConstruction singleCaseArg.PropertyType ->
             [| inputJObject.ToObject(singleCaseArg.PropertyType, serializer) |]
         | multipleFieldsInCustomCaseType ->


### PR DESCRIPTION
Removes two speculative 'features' that can be reaonably argued to be misfeatures on the basis that they were not documented, nor were they covered by tests:
1. `JsonPickler` no longer supports implicit application (via inclusion in the converters list) to parent types or interfaces
   - (also affects `JsonIsomorphism`, which `inherit`s from it)
2. `SystemTextJson.Options`: `autoTypeSafeEnumToJsonString, union = autoUnionToJsonObject` are skipped if the type nominates a specific converter directly (used to also honor tags on base classes/interfaces)

In both cases, the workaround if this greediness was intentionally required, is to override the `CanConvert` member on the converter (or `UnionOrTypeSafeEnumConverterFactory`)