### PR TITLE
chore(SystemTextJson, deps): Target minimum non vulnerable ver: 8.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- `SystemTextJson`: Upped minimum `System.Text.Json` version to `8.0.4` per [CVE-2024-30105](https://github.com/dotnet/announcements/issues/315) [#122](https://github.com/jet/FsCodec/pull/122)
+
 ### Removed
 ### Fixed
 


### PR DESCRIPTION
FsCodec does not lean on the vulnerable method and hence this is not strictly required
Applications that use FsCodec.SystemTextJson will work correctly if v 8.0.4 of `System.Text.Json` is use in the context of the app.