### PR TITLE
feat(TimelineEvent.ToString): Render IsUnfold, EventType, Index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `TimelineEvent.ToString`: Render Unfold/Event state, EventType, Index [#123](https://github.com/jet/FsCodec/pull/123) 
+
 ### Changed
 ### Removed
 ### Fixed

--- a/src/FsCodec/FsCodec.fs
+++ b/src/FsCodec/FsCodec.fs
@@ -89,6 +89,8 @@ type TimelineEvent<'Format>(index, eventType, data, meta, eventId, correlationId
         let size =     defaultArg size 0
         TimelineEvent(index, inner.EventType, inner.Data, inner.Meta, inner.EventId, inner.CorrelationId, inner.CausationId, inner.Timestamp, isUnfold, Option.toObj context, size) :> _
 
+    override _.ToString() = sprintf "%s %s @%i" (if isUnfold then "Unfold" else "Event") eventType index
+    
     interface ITimelineEvent<'Format> with
         member _.Index = index
         member _.IsUnfold = isUnfold


### PR DESCRIPTION
Useful for testing event span ordering with unquote