### PR TITLE
chore(deps): Drop SystemTextJson minimum to 6.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `TimelineEvent.ToString`: Render Unfold/Event state, EventType, Index [#123](https://github.com/jet/FsCodec/pull/123) 
 
 ### Changed
+
+- `SystemTextJson`: Dropped minimum `System.Text.Json` version to `6.0.10` per [CVE-2024-43485](https://github.com/advisories/GHSA-8g4q-xg66-9fp4) [#125](https://github.com/jet/FsCodec/pull/125)
+
 ### Removed
 ### Fixed
 

--- a/src/FsCodec.SystemTextJson/FsCodec.SystemTextJson.fsproj
+++ b/src/FsCodec.SystemTextJson/FsCodec.SystemTextJson.fsproj
@@ -26,7 +26,7 @@
 
     <PackageReference Include="FSharp.Core" Version="4.5.4" />
 
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="6.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/FsCodec.NewtonsoftJson.Tests/FsCodec.NewtonsoftJson.Tests.fsproj
+++ b/tests/FsCodec.NewtonsoftJson.Tests/FsCodec.NewtonsoftJson.Tests.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <DisableImplicitFSharpCoreReference>false</DisableImplicitFSharpCoreReference>
   </PropertyGroup>
 

--- a/tests/FsCodec.SystemTextJson.Tests/FsCodec.SystemTextJson.Tests.fsproj
+++ b/tests/FsCodec.SystemTextJson.Tests/FsCodec.SystemTextJson.Tests.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <DisableImplicitFSharpCoreReference>false</DisableImplicitFSharpCoreReference>
     <DefineConstants>SYSTEM_TEXT_JSON</DefineConstants>
   </PropertyGroup>

--- a/tests/FsCodec.Tests/FsCodec.Tests.fsproj
+++ b/tests/FsCodec.Tests/FsCodec.Tests.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <DisableImplicitFSharpCoreReference>false</DisableImplicitFSharpCoreReference>
   </PropertyGroup>
 


### PR DESCRIPTION
#122 upped the dep to 8.0.4, but dropping it back down as 6.0.10 is a healthy alternative - no CVEs, and the minimum required for the features in this package as per normal minimal policy

Eventually the dependency being upped to 8/10/12.x is inevitable, but no need to rush it