### PR TITLE
feat(EventData): Add MapBodies overload with context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `Core.EventData.MapEx`: Enable contextual encoding of bodies [#127](https://github.com/jet/FsCodec/pull/127)
+
 ### Changed
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 
-- `Core.EventData.MapEx`: Enable contextual encoding of bodies [#127](https://github.com/jet/FsCodec/pull/127)
+- `MapBodies`: Enable contextual encoding of bodies [#127](https://github.com/jet/FsCodec/pull/127)
 
 ### Changed
 ### Removed

--- a/src/FsCodec.Box/Compression.fs
+++ b/src/FsCodec.Box/Compression.fs
@@ -87,7 +87,7 @@ type Compression private () =
     static member EncodeTryCompress<'Event, 'Context>(native: IEventCodec<'Event, ReadOnlyMemory<byte>, 'Context>, [<Optional; DefaultParameterValue null>] ?options)
         : IEventCodec<'Event, EncodedBody, 'Context> =
         let opts = defaultArg options CompressionOptions.Default
-        FsCodec.Core.EventCodec.Map(native, (fun x -> Compression.Utf8ToEncodedTryCompress(opts, x)), Func<_, _> Compression.EncodedToUtf8)
+        FsCodec.Core.EventCodec.Map(native, (fun d -> Compression.Utf8ToEncodedTryCompress(opts, d)), Func<_, _> Compression.EncodedToUtf8)
 
     /// <summary>Adapts an <c>IEventCodec</c> rendering to <c>ReadOnlyMemory&lt;byte&gt;</c> Event Bodies to encode as per <c>EncodeTryCompress</c>, but without attempting compression.</summary>
     [<Extension>]

--- a/src/FsCodec.Box/Compression.fs
+++ b/src/FsCodec.Box/Compression.fs
@@ -87,7 +87,7 @@ type Compression private () =
     static member EncodeTryCompress<'Event, 'Context>(native: IEventCodec<'Event, ReadOnlyMemory<byte>, 'Context>, [<Optional; DefaultParameterValue null>] ?options)
         : IEventCodec<'Event, EncodedBody, 'Context> =
         let opts = defaultArg options CompressionOptions.Default
-        FsCodec.Core.EventCodec.Map(native, (fun d -> Compression.Utf8ToEncodedTryCompress(opts, d)), Func<_, _> Compression.EncodedToUtf8)
+        FsCodec.Core.EventCodec.Map(native, (fun x -> Compression.Utf8ToEncodedTryCompress(opts, x)), Func<_, _> Compression.EncodedToUtf8)
 
     /// <summary>Adapts an <c>IEventCodec</c> rendering to <c>ReadOnlyMemory&lt;byte&gt;</c> Event Bodies to encode as per <c>EncodeTryCompress</c>, but without attempting compression.</summary>
     [<Extension>]

--- a/src/FsCodec.Box/FsCodec.Box.fsproj
+++ b/src/FsCodec.Box/FsCodec.Box.fsproj
@@ -24,6 +24,7 @@
 
     <ItemGroup>
         <ProjectReference Condition=" '$(Configuration)' == 'Debug' " Include="../FsCodec/FsCodec.fsproj" />
+<!--    TODO if taking a dependency on 3.1, the impl should switch to EventCodec.mapBodies, and EventCodec.Map should be Obsoleted -->
         <PackageReference Condition=" '$(Configuration)' == 'Release' " Include="FsCodec" Version="[3.0.0, 4.0.0)" />
     </ItemGroup>
 

--- a/src/FsCodec.SystemTextJson/FsCodec.SystemTextJson.fsproj
+++ b/src/FsCodec.SystemTextJson/FsCodec.SystemTextJson.fsproj
@@ -30,8 +30,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Condition=" '$(Configuration)' == 'Debug' " Include="../FsCodec.Box/FsCodec.Box.fsproj" />
-    <PackageReference Condition=" '$(Configuration)' == 'Release' " Include="FsCodec.Box" Version="[3.0.0, 4.0.0)" />
+    <ProjectReference Include="../FsCodec.Box/FsCodec.Box.fsproj" />
+<!--    NEXT PUBLISHED VERSION will take a 3.1 dependency to avoid using the Obsoleted API-->
+<!--    <ProjectReference Condition=" '$(Configuration)' == 'Debug' " Include="../FsCodec.Box/FsCodec.Box.fsproj" />-->
+<!--    <PackageReference Condition=" '$(Configuration)' == 'Release' " Include="FsCodec.Box" Version="[3.0.0, 4.0.0)" />-->
   </ItemGroup>
 
 </Project>

--- a/src/FsCodec.SystemTextJson/Interop.fs
+++ b/src/FsCodec.SystemTextJson/Interop.fs
@@ -21,7 +21,6 @@ type InteropHelpers private () =
     [<Extension>]
     static member ToUtf8Codec<'Event, 'Context>(native: FsCodec.IEventCodec<'Event, JsonElement, 'Context>)
         : FsCodec.IEventCodec<'Event, ReadOnlyMemory<byte>, 'Context> =
-
         FsCodec.Core.EventCodec.Map(native, Func<_, _> InteropHelpers.JsonElementToUtf8, Func<_, _> InteropHelpers.Utf8ToJsonElement)
 
     /// <summary>Adapts an IEventCodec that's rendering to <c>ReadOnlyMemory&lt;byte&gt;</c> Event Bodies to handle <c>JsonElement</c> bodies instead.<br/>
@@ -29,5 +28,4 @@ type InteropHelpers private () =
     [<Extension>]
     static member ToJsonElementCodec<'Event, 'Context>(native: FsCodec.IEventCodec<'Event, ReadOnlyMemory<byte>, 'Context>)
         : FsCodec.IEventCodec<'Event, JsonElement, 'Context> =
-
         FsCodec.Core.EventCodec.Map(native, Func<_, _> InteropHelpers.Utf8ToJsonElement, Func<_, _> InteropHelpers.JsonElementToUtf8)

--- a/src/FsCodec/FsCodec.fs
+++ b/src/FsCodec/FsCodec.fs
@@ -41,6 +41,7 @@ namespace FsCodec.Core
 
 open FsCodec
 open System
+open System.ComponentModel
 
 /// <summary>An Event about to be written, see <c>IEventData</c> for further information.</summary>
 [<NoComparison; NoEquality>]
@@ -61,8 +62,8 @@ type EventData<'Format>(eventType, data, meta, eventId, correlationId, causation
         member _.CausationId = causationId
         member _.Timestamp = timestamp
 
-    static member MapEx<'Mapped>(f: Func<IEventData<'Format>, 'Format, 'Mapped>)
-        (x: IEventData<'Format>): IEventData<'Mapped> =
+    static member MapBodies<'Mapped>(f: Func<IEventData<'Format>, 'Format, 'Mapped>): Func<IEventData<'Format>, IEventData<'Mapped>> =
+        Func<_, _>(fun x ->
             { new IEventData<'Mapped> with
                 member _.EventType = x.EventType
                 member _.Data = f.Invoke(x, x.Data)
@@ -70,11 +71,22 @@ type EventData<'Format>(eventType, data, meta, eventId, correlationId, causation
                 member _.EventId = x.EventId
                 member _.CorrelationId = x.CorrelationId
                 member _.CausationId = x.CausationId
-                member _.Timestamp = x.Timestamp }
+                member _.Timestamp = x.Timestamp })
 
-    static member Map<'Mapped>(f: Func<'Format, 'Mapped>)
-        (x: IEventData<'Format>): IEventData<'Mapped> =
-        EventData.MapEx(Func<_, _, _>(fun _x -> f.Invoke)) x
+    // Original ugly signature
+    [<Obsolete "Superseded by MapBodies / EventData.mapBodies; more importantly, the original signature mixed F# and C# types so was messy in all contexts"; EditorBrowsable(EditorBrowsableState.Never)>]
+    static member Map<'Mapped>(f: Func<'Format, 'Mapped>) (x: IEventData<'Format>): IEventData<'Mapped> =
+        EventData.MapBodies(Func<_, _, _>(fun _x -> f.Invoke)).Invoke(x)
+
+/// F#-specific wrappers; for C#, use EventData.MapBodies directly
+// These helper modules may move up to the FsCodec namespace in V4, along with breaking changes moving IsUnfold and Context from ITimelineEvent to IEventData
+// If you have helpers that should be in the box alongside these, raise an Issue please
+module EventData =
+
+    let mapBodies_<'Format, 'Mapped> (f: IEventData<'Format> -> 'Format -> 'Mapped) =
+        EventData.MapBodies(Func<IEventData<'Format>, 'Format, 'Mapped> f).Invoke
+    let mapBodies<'Format, 'Mapped> (f: 'Format -> 'Mapped) =
+        EventData.MapBodies(Func<IEventData<'Format>, 'Format, 'Mapped>(fun _ -> f)).Invoke
 
 /// <summary>An Event or Unfold that's been read from a Store and hence has a defined <c>Index</c> on the Event Timeline.</summary>
 [<NoComparison; NoEquality>]
@@ -108,41 +120,66 @@ type TimelineEvent<'Format>(index, eventType, data, meta, eventId, correlationId
         member _.CausationId = causationId
         member _.Timestamp = timestamp
 
-    static member Map<'Mapped>(f: Func<'Format, 'Mapped>)
-        (x: ITimelineEvent<'Format>): ITimelineEvent<'Mapped> =
+    static member MapBodies<'Mapped>(f: Func<ITimelineEvent<'Format>, 'Format, 'Mapped>): Func<ITimelineEvent<'Format>, ITimelineEvent<'Mapped>> =
+        Func<_, _>(fun x ->
             { new ITimelineEvent<'Mapped> with
                 member _.Index = x.Index
                 member _.IsUnfold = x.IsUnfold
                 member _.Context = x.Context
                 member _.Size = x.Size
                 member _.EventType = x.EventType
-                member _.Data = f.Invoke x.Data
-                member _.Meta = f.Invoke x.Meta
+                member _.Data = f.Invoke(x, x.Data)
+                member _.Meta = f.Invoke(x, x.Meta)
                 member _.EventId = x.EventId
                 member _.CorrelationId = x.CorrelationId
                 member _.CausationId = x.CausationId
-                member _.Timestamp = x.Timestamp }
+                member _.Timestamp = x.Timestamp })
+    // Original ugly signature
+    [<Obsolete "Superseded by MapBodies / TimeLineEvent.mapBodies; more importantly, the original signature mixed F# and C# types so was messy in all contexts"; EditorBrowsable(EditorBrowsableState.Never)>]
+    static member Map<'Mapped>(f: Func<'Format, 'Mapped>) (x: ITimelineEvent<'Format>): ITimelineEvent<'Mapped> =
+        TimelineEvent.MapBodies(Func<_, _, _>(fun _x -> f.Invoke)).Invoke(x)
+
+/// F#-specific wrappers; for C#, use TimelineEvent.MapBodies directly
+module TimelineEvent =
+
+    let mapBodies_<'Format, 'Mapped> (f: ITimelineEvent<'Format> -> 'Format -> 'Mapped) =
+        TimelineEvent.MapBodies(Func<ITimelineEvent<'Format>, 'Format, 'Mapped> f).Invoke
+    let mapBodies<'Format, 'Mapped> (f: 'Format -> 'Mapped) =
+        TimelineEvent.MapBodies(Func<ITimelineEvent<'Format>, 'Format, 'Mapped>(fun _ -> f)).Invoke
 
 [<AbstractClass; Sealed>]
 type EventCodec<'Event, 'Format, 'Context> private () =
 
-    static member MapEx<'TargetFormat>(native: IEventCodec<'Event, 'Format, 'Context>, up: Func<IEventData<'Format>, 'Format,'TargetFormat>, down: Func<'TargetFormat, 'Format>)
+    static member MapBodies<'TargetFormat>(
+            native: IEventCodec<'Event, 'Format, 'Context>,
+            up: Func<IEventData<'Format>, 'Format, 'TargetFormat>,
+            down: Func<'TargetFormat, 'Format>)
         : IEventCodec<'Event, 'TargetFormat, 'Context> =
 
-        let upConvert = EventData.MapEx up
-        let downConvert = TimelineEvent.Map down
+        let upConvert = EventData.MapBodies up
+        let downConvert = TimelineEvent.MapBodies(fun _ x -> down.Invoke x)
 
         { new IEventCodec<'Event, 'TargetFormat, 'Context> with
 
             member _.Encode(context, event) =
                 let encoded = native.Encode(context, event)
-                upConvert encoded
+                upConvert.Invoke encoded
 
             member _.Decode target =
-                let encoded = downConvert target
+                let encoded = downConvert.Invoke target
                 native.Decode encoded }
 
-    static member Map<'TargetFormat>(native: IEventCodec<'Event, 'Format, 'Context>, up: Func<'Format,'TargetFormat>, down: Func<'TargetFormat, 'Format>)
+    // NOTE To be be replaced by MapBodies/EventCodec.mapBodies for symmetry with TimelineEvent and EventData
+    // TO BE be Obsoleted and whenever FsCodec.Box is next released
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
+    static member Map<'TargetFormat>(native: IEventCodec<'Event, 'Format, 'Context>, up: Func<'Format, 'TargetFormat>, down: Func<'TargetFormat, 'Format>)
         : IEventCodec<'Event, 'TargetFormat, 'Context> =
+        EventCodec.MapBodies(native, Func<_, _, _>(fun _x -> up.Invoke), down)
 
-        EventCodec.MapEx(native, Func<_, _, _>(fun _x -> up.Invoke), down)
+/// F#-specific wrappers; for C#, use EventCodec.MapBodies directly
+module EventCodec =
+
+    let mapBodies_ (up: IEventData<'Format> -> 'Format -> 'TargetFormat) (down: 'TargetFormat -> 'Format) x =
+        EventCodec<'Event, 'Format, 'Context>.MapBodies<'TargetFormat>(x, up, down)
+    let mapBodies (up: 'Format -> 'TargetFormat) (down: 'TargetFormat -> 'Format) x =
+        EventCodec<'Event, 'Format, 'Context>.MapBodies<'TargetFormat>(x, Func<_, _, _>(fun _ -> up), down)


### PR DESCRIPTION
Passes additional context to the encoding function.

e.g. For `SystemTextJson.Encoding`, this enables the `shouldCompress` predicate to control compression based on the `EventType` etc

NOTE this is a half way house solution - eventually `IEventData` should take over ownership of `IsUnfold` and `Context` from `ITimelineEvent` to afford better control of encoding for DynamoStore and CosmosStore without indirect assumptions